### PR TITLE
Only add local endpoints into the hairpin ipset

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -809,6 +809,9 @@ func (proxier *Proxier) syncProxyRules() {
 				glog.Errorf("Failed to cast BaseEndpointInfo %q", e.String())
 				continue
 			}
+			if !ep.IsLocal {
+				continue
+			}
 			epIP := ep.IP()
 			epPort, err := ep.Port()
 			// Error parsing this endpoint has been logged. Skip to next endpoint.


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes/kubernetes/pull/66149
This should improve performances by ~5-10% (which is good given how simple the patch is) on clusters with ~2000 services.

Flamegraphs currently show SyncIPSetEntries taking 10% of the time in this scenario and I suspect a very large part of it is related to syncing `KUBE-LOOP-BACK` which contains the list of all the endpoints in the cluster... On a large cluster this set can be huge and represent more than half of the ipset entries. In addition, the netlink library does not support ipset and kube-proxy falls back to exec + regex parsing, which is heavy for `KUBE-LOOP-BACK` (set of type `ip,port,ip`)

cc @lallydd 