### PR TITLE
Increase limit for object size in streaming serializer

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming.go
@@ -64,7 +64,7 @@ func NewDecoder(r io.ReadCloser, d runtime.Decoder) Decoder {
 		reader:   r,
 		decoder:  d,
 		buf:      make([]byte, 1024),
-		maxBytes: 1024 * 1024,
+		maxBytes: 16 * 1024 * 1024,
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/streaming/streaming_test.go
@@ -51,7 +51,7 @@ func TestDecoder(t *testing.T) {
 	frames := [][]byte{
 		make([]byte, 1025),
 		make([]byte, 1024*5),
-		make([]byte, 1024*1024*5),
+		make([]byte, 1024*1024*17),
 		make([]byte, 1025),
 	}
 	pr, pw := io.Pipe()


### PR DESCRIPTION
From https://github.com/kubernetes/kubernetes/pull/72053

To avoid

```
Unable to decode an event from the watch stream: object to decode was longer than maximum allowed size
```

e.g. [this](https://ddstaging.datadoghq.com/logs?agg_q=kubernetes_cluster&cols=&event=AQAAAXDUCdP9za_dZwAAAABBWERVQ2Q0eWg3cEFwVHhLeElBSQ&from_ts=1584011494550&index=k8s-platform&live=true&messageDisplay=inline&panel=%22%22&query=%22Unable+to+decode+an+event+from+the+watch+stream%3A+object+to+decode+was+longer+than+maximum+allowed+size%22&stream_sort=desc&to_ts=1584097894550&top_n=10)