### PR TITLE
AWS optimisations for getInstancesByNodeNames() and getCandidateZonesForDynamicVolume()

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -775,6 +775,9 @@ func (s *awsSdkEC2) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*e
 		response, err := s.ec2.DescribeInstances(request)
 		if err != nil {
 			recordAwsMetric("describe_instance", 0, err)
+			if reqerr, ok := err.(awserr.RequestFailure); ok {
+				return nil, fmt.Errorf("error listing AWS instances (requestID: %s): %q", reqerr.RequestID(), err)
+			}
 			return nil, fmt.Errorf("error listing AWS instances: %q", err)
 		}
 

--- a/pkg/cloudprovider/providers/aws/aws_fakes.go
+++ b/pkg/cloudprovider/providers/aws/aws_fakes.go
@@ -490,6 +490,13 @@ func (kms *FakeKMS) DescribeKey(*kms.DescribeKeyInput) (*kms.DescribeKeyOutput, 
 
 func instanceMatchesFilter(instance *ec2.Instance, filter *ec2.Filter) bool {
 	name := *filter.Name
+	if name == "instance-id" {
+		if instance.InstanceId == nil {
+			return false
+		}
+		return contains(filter.Values, *instance.InstanceId)
+	}
+
 	if name == "private-dns-name" {
 		if instance.PrivateDnsName == nil {
 			return false

--- a/pkg/cloudprovider/providers/aws/instances.go
+++ b/pkg/cloudprovider/providers/aws/instances.go
@@ -88,6 +88,25 @@ func (name kubernetesInstanceID) mapToAWSInstanceID() (InstanceID, error) {
 	return InstanceID(awsID), nil
 }
 
+// mapToAWSZone extracts the zone from the KubernetesInstanceID
+func (name kubernetesInstanceID) mapToAWSZone() (string, error) {
+	s := string(name)
+
+	if !strings.HasPrefix(s, "aws://") {
+		return "", fmt.Errorf("Incomplete instance ID, can't extract zone (%s)", name)
+	}
+	url, err := url.Parse(s)
+	if err != nil {
+		return "", fmt.Errorf("Invalid instance name (%s): %v", name, err)
+	}
+
+	tokens := strings.Split(strings.Trim(url.Path, "/"), "/")
+	if len(tokens) != 2 {
+		return "", fmt.Errorf("Instance name has unexpected number of components (%s)", name)
+	}
+	return tokens[0], nil
+}
+
 // mapToAWSInstanceID extracts the InstanceIDs from the Nodes, returning an error if a Node cannot be mapped
 func mapToAWSInstanceIDs(nodes []*v1.Node) ([]InstanceID, error) {
 	var instanceIDs []InstanceID

--- a/pkg/cloudprovider/providers/aws/instances_test.go
+++ b/pkg/cloudprovider/providers/aws/instances_test.go
@@ -127,6 +127,58 @@ func TestParseInstance(t *testing.T) {
 	}
 }
 
+func TestParseInstanceForZone(t *testing.T) {
+	tests := []struct {
+		Kubernetes  kubernetesInstanceID
+		Zone         string
+		ExpectError bool
+	}{
+		{
+			Kubernetes: "aws:///us-east-1a/i-12345678",
+			Zone:        "us-east-1a",
+		},
+		{
+			Kubernetes: "aws:////i-12345678",
+			ExpectError: true,
+		},
+		{
+			Kubernetes: "i-12345678",
+			ExpectError: true,
+		},
+		{
+			Kubernetes: "aws:///us-east-1a/i-12345678abcdef01",
+			Zone:        "us-east-1a",
+		},
+		{
+			Kubernetes: "aws:////i-12345678abcdef01",
+			ExpectError: true,
+		},
+		{
+			Kubernetes: "i-12345678abcdef01",
+			ExpectError: true,
+		},
+		{
+			Kubernetes:  "",
+			ExpectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		awsZone, err := test.Kubernetes.mapToAWSZone()
+		if err != nil {
+			if !test.ExpectError {
+				t.Errorf("unexpected error parsing %s: %v", test.Kubernetes, err)
+			}
+		} else {
+			if test.ExpectError {
+				t.Errorf("expected error parsing %s", test.Kubernetes)
+			} else if test.Zone != awsZone {
+				t.Errorf("unexpected value parsing %s, got %s", test.Kubernetes, awsZone)
+			}
+		}
+	}
+}
+
 func TestSnapshotMeetsCriteria(t *testing.T) {
 	snapshot := &allInstancesSnapshot{timestamp: time.Now().Add(-3601 * time.Second)}
 

--- a/pkg/cloudprovider/providers/aws/volumes.go
+++ b/pkg/cloudprovider/providers/aws/volumes.go
@@ -119,7 +119,7 @@ func (c *Cloud) checkIfAttachedToNode(diskName KubernetesVolumeID, nodeName type
 	info, err := disk.describeVolume()
 
 	if err != nil {
-		glog.Warning("Error describing volume %s with %v", diskName, err)
+		glog.Warningf("Error describing volume %s with %v", diskName, err)
 		awsDiskInfo.volumeState = "unknown"
 		return awsDiskInfo, false, err
 	}


### PR DESCRIPTION
* Lookup by instance-id in aws.go getInstancesByNodeNames()
* Use node-informer for getCandidateZonesForDynamicVolume() (eliminates describe-instances call to retrieve all running instances)
* Make DescribeInstances() log the AWS requestID on error
