### PR TITLE
Fix race condition in calls to convertToAPIContainerStatuses

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1512,11 +1512,15 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		statuses[container.Name] = status
 	}
 
+	// Clone container statuses to make sorting thread-safe
+	containerStatusesCopy := make([]*kubecontainer.ContainerStatus, len(podStatus.ContainerStatuses))
+	copy(containerStatusesCopy, podStatus.ContainerStatuses)
+
 	// Make the latest container status comes first.
-	sort.Sort(sort.Reverse(kubecontainer.SortContainerStatusesByCreationTime(podStatus.ContainerStatuses)))
+	sort.Sort(sort.Reverse(kubecontainer.SortContainerStatusesByCreationTime(containerStatusesCopy)))
 	// Set container statuses according to the statuses seen in pod status
 	containerSeen := map[string]int{}
-	for _, cStatus := range podStatus.ContainerStatuses {
+	for _, cStatus := range containerStatusesCopy {
 		cName := cStatus.Name
 		if _, ok := statuses[cName]; !ok {
 			// This would also ignore the infra container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

There is a race condition between the kubelet `SyncLoop` when the PLEG issues a `ContainerDied` event and the pod worker `syncPod` call.

This race condition is triggered by : 
- In the SyncLoop, the call to `cleanUpContainersInPod` which in turn calls `generateAPIPodStatus` on a podStatus pointer fetched from the pod cache https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go#L2211-L2222
- In the pod workers, the call to `syncPod` which in turn also calls `generateAPIPodStatus` on a podStatus pointer fetched from the pod cache https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet.go#L1494

`generateAPIPodStatus` would eventually call `convertToAPIContainerStatuses` that sorts podStatus.ContainerStatuses in place. This is not a thread-safe operation, and when called concurrently, leads to the resulting `podStatus.ContainerStatuses` missing some entries and having some entries as duplicates.

At this point, the pod cache is containing a `podStatus` that is missing some containers statuses, thus `computePodActions` https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L477  will try creating the missing containers.

However, as those containers may already be running, this leads the pod to be in `CreateContainerError` that does not recover until either the kubelet is restarted or another mechanism causes a refresh of the runtime state and a Set to the podCache. 
