### PR TITLE
[1.14-dd] BackPort of kubernetes PR# 93457

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -179,7 +179,7 @@ func (spc *realStatefulPodControl) recordClaimEvent(verb string, set *apps.State
 func (spc *realStatefulPodControl) createPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
 	var errs []error
 	for _, claim := range getPersistentVolumeClaims(set, pod) {
-		_, err := spc.pvcLister.PersistentVolumeClaims(claim.Namespace).Get(claim.Name)
+		pvc, err := spc.pvcLister.PersistentVolumeClaims(claim.Namespace).Get(claim.Name)
 		switch {
 		case apierrors.IsNotFound(err):
 			_, err := spc.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(&claim)
@@ -192,6 +192,10 @@ func (spc *realStatefulPodControl) createPersistentVolumeClaims(set *apps.Statef
 		case err != nil:
 			errs = append(errs, fmt.Errorf("Failed to retrieve PVC %s: %s", claim.Name, err))
 			spc.recordClaimEvent("create", set, pod, &claim, err)
+		case err == nil:
+			if pvc.DeletionTimestamp != nil {
+				errs = append(errs, fmt.Errorf("pvc %s is being deleted", claim.Name))
+			}
 		}
 		// TODO: Check resource requirements and accessmodes, update if necessary
 	}

--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -20,8 +20,10 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	core "k8s.io/client-go/testing"
@@ -121,6 +123,42 @@ func TestStatefulPodControlCreatePodPvcCreateFailure(t *testing.T) {
 	events := collectEvents(recorder.Events)
 	if eventCount := len(events); eventCount != 2 {
 		t.Errorf("PVC create failure: got %d events, but want 2", eventCount)
+	}
+	for i := range events {
+		if !strings.Contains(events[i], v1.EventTypeWarning) {
+			t.Errorf("Found unexpected non-warning event %s", events[i])
+		}
+	}
+}
+func TestStatefulPodControlCreatePodPvcDeleting(t *testing.T) {
+	recorder := record.NewFakeRecorder(10)
+	set := newStatefulSet(3)
+	pod := newStatefulSetPod(set, 0)
+	fakeClient := &fake.Clientset{}
+	pvcs := getPersistentVolumeClaims(set, pod)
+	pvcIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+	deleteTime := time.Date(2019, time.January, 1, 0, 0, 0, 0, time.UTC)
+	for k := range pvcs {
+		pvc := pvcs[k]
+		pvc.DeletionTimestamp = &metav1.Time{Time: deleteTime}
+		pvcIndexer.Add(&pvc)
+	}
+	pvcLister := corelisters.NewPersistentVolumeClaimLister(pvcIndexer)
+	control := NewRealStatefulPodControl(fakeClient, nil, nil, pvcLister, recorder)
+	fakeClient.AddReactor("create", "persistentvolumeclaims", func(action core.Action) (bool, runtime.Object, error) {
+		create := action.(core.CreateAction)
+		return true, create.GetObject(), nil
+	})
+	fakeClient.AddReactor("create", "pods", func(action core.Action) (bool, runtime.Object, error) {
+		create := action.(core.CreateAction)
+		return true, create.GetObject(), nil
+	})
+	if err := control.CreateStatefulPod(set, pod); err == nil {
+		t.Error("Failed to produce error on deleting PVC")
+	}
+	events := collectEvents(recorder.Events)
+	if eventCount := len(events); eventCount != 1 {
+		t.Errorf("Deleting PVC: got %d events, but want 1", eventCount)
 	}
 	for i := range events {
 		if !strings.Contains(events[i], v1.EventTypeWarning) {


### PR DESCRIPTION
## Overview
Cherry-picks [kubernetes PR# 93457 :: Do not create StatefulSet pods when PVC is being deleted](https://github.com/kubernetes/kubernetes/pull/93457) into 1.14.dd branch

I found PR#93457 to be mis-leading. The code review from cofyc requests 'add PVC reconciliation'. In response, a _suggested_ change was then posted as a comment, but never actually committed on the branch. So now it stands to reason that the issue brought up by member cofyc may still be an issue based on the remark:

> yes, after some investigations, we found that hitting the issue (pod has no PVC to use) is high if the PVC is deleted after the controller checks the PVC's state because the PVC can be deleted successfully if the newly created pod is not scheduled, see the discussion here: #74374
my suggestions:
o checking the deletion timestamp (live call maybe is not needed as we will have PVC reconciliation)
o add PVC reconciliation

Non-with-standing, the backport of _this_ PR is only the content that merged to upstream master, and the suggested change was not tested.

## Notes
- The original PR is milestone 1.20 in upstream kubernetes.
- Building and testing this on my mac was not easy-going with 6G memory. I could never get all tests to run without OOM. I ended up building on my Linux server. Also found that it is actually necessary to do the 'make cross' (cross compile all architectures) for tests to run clean. Seems so wasteful to build for all those platforms just to run tests.

## Reference
- [COMPUTE-644](https://datadoghq.atlassian.net/browse/COMPUTE-644)

