### PR TITLE
Build and release pause container images

### DIFF
--- a/.github/workflows/dd-build.yml
+++ b/.github/workflows/dd-build.yml
@@ -6,6 +6,7 @@ on:
     tags:
     # Push events on datadog tags
     - "*-dd*"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,9 +14,7 @@ jobs:
       matrix:
         platform: ["linux/arm64","linux/amd64"]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v3
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/dd-build.yml
+++ b/.github/workflows/dd-build.yml
@@ -19,11 +19,31 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: 1.15
+    - name: Setup Docker buildx
+      uses: docker/setup-buildx-action@v2
     - name: Build
       env:
         KUBE_BUILD_PLATFORMS: ${{ matrix.platform }}
         KUBE_RELEASE_RUN_TESTS: n
       run: make quick-release KUBE_BUILD_PLATFORMS=$KUBE_BUILD_PLATFORMS
+    - name: Build pause container image
+      shell: bash
+      env:
+        KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
+        REGISTRY: k8s.datadoghq.com
+      run: |
+        TARGET_PLATFORM="${KUBE_BUILD_PLATFORM/\//-}"
+        OS="${KUBE_BUILD_PLATFORM%%/*}"
+        ARCH="${KUBE_BUILD_PLATFORM##*/}"
+        cd ./build/pause
+        PAUSE_TAG=$(awk '/^TAG = [0-9.]+$/ { print $3}' Makefile)
+        make container OS=${OS} ARCH=${ARCH} REGISTRY=${REGISTRY}
+        cd ../..
+        docker save -o _output/release-tars/pause-${TARGET_PLATFORM}.tar ${REGISTRY}/pause:${PAUSE_TAG}-${TARGET_PLATFORM}
+        gzip -v _output/release-tars/pause-${TARGET_PLATFORM}.tar
+        echo ${PAUSE_TAG} > pause-tag.txt
+        tar czf _output/release-tars/pause-tag-${TARGET_PLATFORM}.tar.gz pause-tag.txt
+        ls -l _output/release-tars
     - name: Calculate checksums
       id: calculate_checksums
       shell: bash
@@ -91,7 +111,9 @@ jobs:
         assets: [
            "kubernetes-client",
            "kubernetes-node",
-           "kubernetes-server"
+           "kubernetes-server",
+           "pause",
+           "pause-tag"
         ]
         platform: ["linux-arm64","linux-amd64"]
         extension: ["tar.gz", "tar.gz.sha256sum"]


### PR DESCRIPTION
CMPT-1202: Build pause container images and push tar exports into the release.

[CMPT-1202]: https://datadoghq.atlassian.net/browse/CMPT-1202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ