### PR TITLE
[ghactions] Upgrade to checkout v3 + don't pull history

### DIFF
--- a/.github/workflows/dd-build.yml
+++ b/.github/workflows/dd-build.yml
@@ -6,6 +6,7 @@ on:
     tags:
     # Push events on datadog tags
     - "*-dd*"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,9 +14,7 @@ jobs:
       matrix:
         platform: ["linux/arm64","linux/amd64"]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v3
     - name: Set up Go
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
`fetch-depth: 0` says "pull the whole history". We should use the default instead.

Also, upgrade to v3 while we're at it.