### PR TITLE
Add labels to service acount token stale and legacy metrics

### DIFF
--- a/pkg/serviceaccount/claims.go
+++ b/pkg/serviceaccount/claims.go
@@ -203,7 +203,7 @@ func (v *validator) Validate(ctx context.Context, _ string, public *jwt.Claims, 
 			secondsAfterWarn := nowTime.Unix() - warnafter.Time().Unix()
 			auditInfo := fmt.Sprintf("subject: %s, seconds after warning threshold: %d", public.Subject, secondsAfterWarn)
 			audit.AddAuditAnnotation(ctx, "authentication.k8s.io/stale-token", auditInfo)
-			staleTokensTotal.WithContext(ctx).Inc()
+			staleTokensTotal.WithContext(ctx).WithLabelValues(saref.Name, namespace).Inc()
 		} else {
 			validTokensTotal.WithContext(ctx).Inc()
 		}

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -294,7 +294,7 @@ func (j *jwtTokenAuthenticator) AuthenticateToken(ctx context.Context, tokenData
 	if len(tokenAudiences) == 0 {
 		// only apiserver audiences are allowed for legacy tokens
 		audit.AddAuditAnnotation(ctx, "authentication.k8s.io/legacy-token", public.Subject)
-		legacyTokensTotal.WithContext(ctx).Inc()
+		legacyTokensTotal.WithContext(ctx).WithLabelValues(public.Subject).Inc()
 		tokenAudiences = j.implicitAuds
 	}
 

--- a/pkg/serviceaccount/metrics.go
+++ b/pkg/serviceaccount/metrics.go
@@ -27,24 +27,24 @@ const kubeServiceAccountSubsystem = "serviceaccount"
 
 var (
 	// LegacyTokensTotal is the number of legacy tokens used against apiserver.
-	legacyTokensTotal = metrics.NewCounter(
+	legacyTokensTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      kubeServiceAccountSubsystem,
 			Name:           "legacy_tokens_total",
 			Help:           "Cumulative legacy service account tokens used",
 			StabilityLevel: metrics.ALPHA,
-		},
+		}, []string{"subject"},
 	)
 
 	// StaleTokensTotal is the number of stale projected tokens not refreshed on
 	// client side.
-	staleTokensTotal = metrics.NewCounter(
+	staleTokensTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      kubeServiceAccountSubsystem,
 			Name:           "stale_tokens_total",
 			Help:           "Cumulative stale projected service account tokens used",
 			StabilityLevel: metrics.ALPHA,
-		},
+		}, []string{"serviceaccount", "sa_namespace"},
 	)
 
 	// ValidTokensTotal is the number of valid projected tokens used.


### PR DESCRIPTION
This should help track down if there are any