### PR TITLE
Release v1.31.6-dd.1

### DIFF
--- a/.github/workflows/dd-build.yml
+++ b/.github/workflows/dd-build.yml
@@ -1,0 +1,135 @@
+name: Build and Push k8s Release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    tags:
+    # Push events on datadog tags
+    - "*-dd*"
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ["linux/arm64","linux/amd64"]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.22
+    - name: Set env
+      run: echo SANITIZED_TARGET_PLATFORM=${KUBE_BUILD_PLATFORM/\//-} >> $GITHUB_ENV
+      env:
+        KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
+    - name: Cleanup disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/local/.ghcup
+    - name: Build
+      env:
+        KUBE_BUILD_PLATFORMS: ${{ matrix.platform }}
+        KUBE_RELEASE_RUN_TESTS: n
+      run: make quick-release KUBE_BUILD_PLATFORMS=$KUBE_BUILD_PLATFORMS
+    - name: Calculate checksums
+      id: calculate_checksums
+      shell: bash
+      working-directory: _output/release-tars
+      env:
+        KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
+      run: |
+        TARGET_PLATFORM="${KUBE_BUILD_PLATFORM/\//-}"
+        for TARGET_FILE in *"${TARGET_PLATFORM}".tar.gz
+        do
+          sha256sum "$TARGET_FILE" > "${TARGET_FILE}.sha256sum"
+        done
+    - uses: actions/upload-artifact@v4
+      with:
+        name: k8s_output_${{ env.SANITIZED_TARGET_PLATFORM }}
+        path: _output/release-tars
+      env:
+        SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      upload_url: ${{ steps.create_release_branch.outputs.upload_url }}${{ steps.create_release_tags.outputs.upload_url }}
+    steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+      env:
+        GITHUB_REF: ${{ github.ref }}
+      if: startsWith(github.ref, 'refs/heads/')
+    - name: Create Release for Branch
+      id: create_release_branch
+      uses: softprops/action-gh-release@v2
+      if: startsWith(github.ref, 'refs/heads/')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: branch@${{ steps.extract_branch.outputs.branch  }}
+        tag_name: branch@${{ steps.extract_branch.outputs.branch  }}
+        draft: false
+        prerelease: false
+    - name: Extract tags name
+      shell: bash
+      run: echo "##[set-output name=tags;]$(echo ${GITHUB_REF#refs/tags/})"
+      id: extract_tags
+      env:
+        GITHUB_REF: ${{ github.ref }}
+      if: startsWith(github.ref, 'refs/tags/')
+    - name: Create Release for Tags
+      id: create_release_tags
+      uses: softprops/action-gh-release@v2
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: ${{ steps.extract_tags.outputs.tags }}
+        tag_name: ${{ steps.extract_tags.outputs.tags }}
+        release_name: ${{ steps.extract_tags.outputs.tags }}
+        draft: false
+        prerelease: false
+  releaseassetsarm:
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        assets: [
+           "kubernetes-client",
+           "kubernetes-node",
+           "kubernetes-server"
+        ]
+        platform: ["linux-arm64","linux-amd64"]
+        extension: ["tar.gz", "tar.gz.sha256sum"]
+    steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: k8s_output_${{ matrix.platform }}
+        path: _output/release-tars
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: _output
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ./_output/release-tars/${{ matrix.assets }}-${{ matrix.platform }}.${{ matrix.extension}}
+        asset_name: ${{ matrix.assets }}-${{ matrix.platform }}.${{ matrix.extension }}
+        asset_content_type: application/tar+gzip

--- a/.github/workflows/dd-build.yml
+++ b/.github/workflows/dd-build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22
+        go-version: 1.23
     - name: Set env
       run: echo SANITIZED_TARGET_PLATFORM=${KUBE_BUILD_PLATFORM/\//-} >> $GITHUB_ENV
       env:
@@ -34,9 +34,10 @@ jobs:
         sudo rm -rf /usr/local/.ghcup
     - name: Build
       env:
+        GOFLAGS: "-tags=fips"
         KUBE_BUILD_PLATFORMS: ${{ matrix.platform }}
         KUBE_RELEASE_RUN_TESTS: n
-      run: make quick-release KUBE_BUILD_PLATFORMS=$KUBE_BUILD_PLATFORMS
+      run: make quick-release CGO_ENABLED=1 KUBE_CGO_OVERRIDES="kube-apiserver kube-controller-manager kube-scheduler kubelet" KUBE_BUILD_PLATFORMS=$KUBE_BUILD_PLATFORMS GOFLAGS=$GOFLAGS
     - name: Calculate checksums
       id: calculate_checksums
       shell: bash

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -55,3 +55,8 @@ ADD rsyncd.password /
 RUN chmod a+r /rsyncd.password
 ADD rsyncd.sh /
 RUN chmod a+rx /rsyncd.sh
+
+# Enable fips build
+ENV GOEXPERIMENT=boringcrypto
+# Enable debug to keep symbols around, allowing us to do go tool nm
+ENV DBG=1

--- a/cmd/kube-apiserver/fips.go
+++ b/cmd/kube-apiserver/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/cmd/kube-controller-manager/fips.go
+++ b/cmd/kube-controller-manager/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/cmd/kube-scheduler/fips.go
+++ b/cmd/kube-scheduler/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/cmd/kubectl/fips.go
+++ b/cmd/kubectl/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/cmd/kubelet/fips.go
+++ b/cmd/kubelet/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -729,6 +729,12 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.
 
 	l := getContainerInfoFromLabels(s.Labels)
 	a := getContainerInfoFromAnnotations(s.Annotations)
+
+	annotations := make(map[string]string)
+	if a.Sidecar {
+		annotations[fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", l.ContainerName)] = "Sidecar"
+	}
+
 	// Notice that the followings are not full spec. The container killing code should not use
 	// un-restored fields.
 	pod = &v1.Pod{
@@ -737,6 +743,7 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.
 			Name:                       l.PodName,
 			Namespace:                  l.PodNamespace,
 			DeletionGracePeriodSeconds: a.PodDeletionGracePeriod,
+			Annotations:                annotations,
 		},
 		Spec: v1.PodSpec{
 			TerminationGracePeriodSeconds: a.PodTerminationGracePeriod,
@@ -762,8 +769,15 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 	var containerSpec *v1.Container
 	if pod != nil {
 		if containerSpec = kubecontainer.GetContainerSpec(pod, containerName); containerSpec == nil {
-			return fmt.Errorf("failed to get containerSpec %q (id=%q) in pod %q when killing container for reason %q",
-				containerName, containerID.String(), format.Pod(pod), message)
+			// after a kubelet restart, it's not 100% certain that the
+			// pod we're given has the container we need in the spec
+			// -- we try to recover that here.
+			restoredPod, restoredContainer, err := m.restoreSpecsFromContainerLabels(ctx, containerID)
+			if err != nil {
+				return fmt.Errorf("failed to get containerSpec %q(id=%q) in pod %q when killing container for reason %q. error: %v",
+					containerName, containerID.String(), format.Pod(pod), message, err)
+			}
+			pod, containerSpec = restoredPod, restoredContainer
 		}
 	} else {
 		// Restore necessary information if one of the specs is nil.
@@ -826,9 +840,27 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 
 // killContainersWithSyncResult kills all pod's containers with sync results.
 func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) (syncResults []*kubecontainer.SyncResult) {
-	containerResults := make(chan *kubecontainer.SyncResult, len(runningPod.Containers))
-	wg := sync.WaitGroup{}
+	// split out sidecars and non-sidecars
+	var (
+		sidecars    []*kubecontainer.Container
+		nonSidecars []*kubecontainer.Container
+	)
 
+	if gracePeriodOverride == nil {
+		minGracePeriod := int64(minimumGracePeriodInSeconds)
+		gracePeriodOverride = &minGracePeriod
+	}
+
+	for _, container := range runningPod.Containers {
+		if isSidecar(pod, container.Name) {
+			sidecars = append(sidecars, container)
+		} else {
+			nonSidecars = append(nonSidecars, container)
+		}
+	}
+	containerResults := make(chan *kubecontainer.SyncResult, len(runningPod.Containers))
+
+	wg := sync.WaitGroup{}
 	wg.Add(len(runningPod.Containers))
 	var termOrdering *terminationOrdering
 	// we only care about container termination ordering if the sidecars feature is enabled
@@ -839,6 +871,15 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 		}
 		termOrdering = newTerminationOrdering(pod, runningContainerNames)
 	}
+
+	if len(sidecars) > 0 {
+		var runningContainerNames []string
+		for _, container := range runningPod.Containers {
+			runningContainerNames = append(runningContainerNames, container.Name)
+		}
+		termOrdering = lyftSidecarTerminationOrdering(pod, runningContainerNames)
+	}
+
 	for _, container := range runningPod.Containers {
 		go func(container *kubecontainer.Container) {
 			defer utilruntime.HandleCrash()

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
+	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/kubernetes/pkg/kubelet/sysctl"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/cache"
@@ -540,6 +541,14 @@ func containerSucceeded(c *v1.Container, podStatus *kubecontainer.PodStatus) boo
 	return cStatus.ExitCode == 0
 }
 
+func isSidecar(pod *v1.Pod, containerName string) bool {
+	if pod == nil {
+		klog.V(5).Infof("isSidecar: pod is nil, so returning false")
+		return false
+	}
+	return pod.Annotations[fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", containerName)] == "Sidecar"
+}
+
 func isInPlacePodVerticalScalingAllowed(pod *v1.Pod) bool {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		return false
@@ -835,6 +844,17 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 
 	handleRestartableInitContainers := utilfeature.DefaultFeatureGate.Enabled(features.SidecarContainers) && types.HasRestartableInitContainer(pod)
 
+	var sidecarNames []string
+	for _, container := range pod.Spec.Containers {
+		if isSidecar(pod, container.Name) {
+			sidecarNames = append(sidecarNames, container.Name)
+		}
+	}
+
+	// determine sidecar status
+	sidecarStatus := status.GetSidecarsStatus(pod)
+	klog.Infof("Pod: %s, sidecars: %s, status: Present=%v,Ready=%v,ContainersWaiting=%v", format.Pod(pod), sidecarNames, sidecarStatus.SidecarsPresent, sidecarStatus.SidecarsReady, sidecarStatus.ContainersWaiting)
+
 	// If we need to (re-)create the pod sandbox, everything will need to be
 	// killed and recreated, and init containers should be purged.
 	if createPodSandbox {
@@ -890,7 +910,22 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 
 			return changes
 		}
-		changes.ContainersToStart = containersToStart
+		if len(sidecarNames) > 0 {
+			for idx, c := range pod.Spec.Containers {
+				if isSidecar(pod, c.Name) {
+					changes.ContainersToStart = append(changes.ContainersToStart, idx)
+				}
+			}
+			return changes
+		}
+		// Start all containers by default but exclude the ones that
+		// succeeded if RestartPolicy is OnFailure
+		for idx, c := range pod.Spec.Containers {
+			if containerSucceeded(&c, podStatus) && pod.Spec.RestartPolicy == v1.RestartPolicyOnFailure {
+				continue
+			}
+			changes.ContainersToStart = append(changes.ContainersToStart, idx)
+		}
 		return changes
 	}
 
@@ -951,6 +986,21 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	keepCount := 0
 	// check the status of containers.
 	for idx, container := range pod.Spec.Containers {
+		// this works because in other cases, if it was a sidecar, we
+		// are always allowed to handle the container.
+		//
+		// if it is a non-sidecar, and there are no sidecars, then
+		// we're are also always allowed to restart the container.
+		//
+		// if there are sidecars, then we can only restart non-sidecars under
+		// the following conditions:
+		// - the non-sidecars have run before (i.e. they are not in a Waiting state) OR
+		// - the sidecars are ready (we're starting them for the first time)
+		if !isSidecar(pod, container.Name) && sidecarStatus.SidecarsPresent && sidecarStatus.ContainersWaiting && !sidecarStatus.SidecarsReady {
+			klog.Infof("Pod: %s, Container: %s, sidecar=%v skipped: Present=%v,Ready=%v,ContainerWaiting=%v", format.Pod(pod), container.Name, isSidecar(pod, container.Name), sidecarStatus.SidecarsPresent, sidecarStatus.SidecarsReady, sidecarStatus.ContainersWaiting)
+			continue
+		}
+
 		containerStatus := podStatus.FindContainerStatusByName(container.Name)
 
 		// Call internal container post-stop lifecycle hook for any non-running container so that any
@@ -1028,6 +1078,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	}
 
 	if keepCount == 0 && len(changes.ContainersToStart) == 0 {
+		klog.Infof("Pod: %s: KillPod=true", format.Pod(pod))
 		changes.KillPod = true
 		if handleRestartableInitContainers {
 			// To prevent the restartable init containers to keep pod alive, we should
@@ -1457,6 +1508,35 @@ func (m *kubeGenericRuntimeManager) doBackOff(pod *v1.Pod, container *v1.Contain
 // only hard kill paths are allowed to specify a gracePeriodOverride in the kubelet in order to not corrupt user data.
 // it is useful when doing SIGKILL for hard eviction scenarios, or max grace period during soft eviction scenarios.
 func (m *kubeGenericRuntimeManager) KillPod(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+	// if the pod is nil, we need to recover it, so we can get the
+	// grace period and also the sidecar status.
+	if pod == nil {
+		for _, container := range runningPod.Containers {
+			klog.Infof("Pod: %s, KillPod: pod nil, trying to restore from container %s", runningPod.Name, container.ID)
+			podSpec, _, err := m.restoreSpecsFromContainerLabels(ctx, container.ID)
+			if err != nil {
+				klog.Errorf("Pod: %s, KillPod: couldn't restore: %s", runningPod.Name, container.ID)
+				continue
+			}
+			pod = podSpec
+			break
+		}
+	}
+
+	if gracePeriodOverride == nil && pod != nil {
+		switch {
+		case pod.DeletionGracePeriodSeconds != nil:
+			gracePeriodOverride = pod.DeletionGracePeriodSeconds
+		case pod.Spec.TerminationGracePeriodSeconds != nil:
+			gracePeriodOverride = pod.Spec.TerminationGracePeriodSeconds
+		}
+	}
+
+	if gracePeriodOverride == nil || *gracePeriodOverride < minimumGracePeriodInSeconds {
+		min := int64(minimumGracePeriodInSeconds)
+		gracePeriodOverride = &min
+	}
+
 	err := m.killPodWithSyncResult(ctx, pod, runningPod, gracePeriodOverride)
 	return err.Error()
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1117,29 +1117,32 @@ func TestComputePodActions(t *testing.T) {
 				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
 			},
 		},
-		"Verify we do not create a pod sandbox if no ready sandbox for pod with RestartPolicy=OnFailure and all containers succeeded": {
-			mutatePodFn: func(pod *v1.Pod) {
-				pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
+		// For now the a2a9964a66ef481d10db3ffc15d4b26a234d0bdd fix isn't compatible with the sidecar patchset we keep in this fork. Comment out related tests.
+		/*
+			"Verify we do not create a pod sandbox if no ready sandbox for pod with RestartPolicy=OnFailure and all containers succeeded": {
+				mutatePodFn: func(pod *v1.Pod) {
+					pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
+				},
+				mutateStatusFn: func(status *kubecontainer.PodStatus) {
+					// no ready sandbox
+					status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+					status.SandboxStatuses[0].Metadata.Attempt = uint32(1)
+					// all containers succeeded
+					for i := range status.ContainerStatuses {
+						status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
+						status.ContainerStatuses[i].ExitCode = 0
+					}
+				},
+				actions: podActions{
+					SandboxID:         baseStatus.SandboxStatuses[0].Id,
+					Attempt:           uint32(2),
+					CreateSandbox:     false,
+					KillPod:           true,
+					ContainersToStart: []int{},
+					ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
+				},
 			},
-			mutateStatusFn: func(status *kubecontainer.PodStatus) {
-				// no ready sandbox
-				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
-				status.SandboxStatuses[0].Metadata.Attempt = uint32(1)
-				// all containers succeeded
-				for i := range status.ContainerStatuses {
-					status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
-					status.ContainerStatuses[i].ExitCode = 0
-				}
-			},
-			actions: podActions{
-				SandboxID:         baseStatus.SandboxStatuses[0].Id,
-				Attempt:           uint32(2),
-				CreateSandbox:     false,
-				KillPod:           true,
-				ContainersToStart: []int{},
-				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
-			},
-		},
+		*/
 		"Verify we create a pod sandbox if no ready sandbox for pod with RestartPolicy=Never and no containers have ever been created": {
 			mutatePodFn: func(pod *v1.Pod) {
 				pod.Spec.RestartPolicy = v1.RestartPolicyNever
@@ -1393,40 +1396,43 @@ func testComputePodActionsWithInitContainers(t *testing.T, sidecarContainersEnab
 				ContainersToKill:  getKillMapWithInitContainers(basePod, baseStatus, []int{}),
 			},
 		},
-		"Pod sandbox not ready, and RestartPolicy == Never, but no visible init containers;  create a new pod sandbox": {
-			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyNever },
-			mutateStatusFn: func(status *kubecontainer.PodStatus) {
-				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
-				status.ContainerStatuses = []*kubecontainer.Status{}
+		// For now the a2a9964a66ef481d10db3ffc15d4b26a234d0bdd fix isn't compatible with the sidecar patchset we keep in this fork. Comment out related tests.
+		/*
+			"Pod sandbox not ready, and RestartPolicy == Never, but no visible init containers;  create a new pod sandbox": {
+				mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyNever },
+				mutateStatusFn: func(status *kubecontainer.PodStatus) {
+					status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+					status.ContainerStatuses = []*kubecontainer.Status{}
+				},
+				actions: podActions{
+					KillPod:                  true,
+					CreateSandbox:            true,
+					SandboxID:                baseStatus.SandboxStatuses[0].Id,
+					Attempt:                  uint32(1),
+					NextInitContainerToStart: &basePod.Spec.InitContainers[0],
+					InitContainersToStart:    []int{0},
+					ContainersToStart:        []int{},
+					ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
+				},
 			},
-			actions: podActions{
-				KillPod:                  true,
-				CreateSandbox:            true,
-				SandboxID:                baseStatus.SandboxStatuses[0].Id,
-				Attempt:                  uint32(1),
-				NextInitContainerToStart: &basePod.Spec.InitContainers[0],
-				InitContainersToStart:    []int{0},
-				ContainersToStart:        []int{},
-				ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
+			"Pod sandbox not ready, init container failed, and RestartPolicy == OnFailure; create a new pod sandbox": {
+				mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure },
+				mutateStatusFn: func(status *kubecontainer.PodStatus) {
+					status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+					status.ContainerStatuses[2].ExitCode = 137
+				},
+				actions: podActions{
+					KillPod:                  true,
+					CreateSandbox:            true,
+					SandboxID:                baseStatus.SandboxStatuses[0].Id,
+					Attempt:                  uint32(1),
+					NextInitContainerToStart: &basePod.Spec.InitContainers[0],
+					InitContainersToStart:    []int{0},
+					ContainersToStart:        []int{},
+					ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
+				},
 			},
-		},
-		"Pod sandbox not ready, init container failed, and RestartPolicy == OnFailure; create a new pod sandbox": {
-			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure },
-			mutateStatusFn: func(status *kubecontainer.PodStatus) {
-				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
-				status.ContainerStatuses[2].ExitCode = 137
-			},
-			actions: podActions{
-				KillPod:                  true,
-				CreateSandbox:            true,
-				SandboxID:                baseStatus.SandboxStatuses[0].Id,
-				Attempt:                  uint32(1),
-				NextInitContainerToStart: &basePod.Spec.InitContainers[0],
-				InitContainersToStart:    []int{0},
-				ContainersToStart:        []int{},
-				ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
-			},
-		},
+		*/
 		"some of the init container statuses are missing but the last init container is running, don't restart preceding ones": {
 			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
@@ -1922,6 +1928,13 @@ func makeBasePodAndStatusWithRestartableInitContainers() (*v1.Pod, *kubecontaine
 	return pod, status
 }
 
+func makeBasePodAndStatusWithSidecar() (*v1.Pod, *kubecontainer.PodStatus) {
+	pod, status := makeBasePodAndStatus()
+	pod.Annotations = map[string]string{fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", pod.Spec.Containers[1].Name): "Sidecar"}
+	status.ContainerStatuses[1].Hash = kubecontainer.HashContainer(&pod.Spec.Containers[1])
+	return pod, status
+}
+
 func TestComputePodActionsWithInitAndEphemeralContainers(t *testing.T) {
 	// Make sure existing test cases pass with feature enabled
 	TestComputePodActions(t)
@@ -2005,24 +2018,27 @@ func testComputePodActionsWithInitAndEphemeralContainers(t *testing.T, sidecarCo
 				EphemeralContainersToStart: []int{0},
 			},
 		},
-		"Create a new pod sandbox if the pod sandbox is dead, init container failed and RestartPolicy == OnFailure": {
-			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure },
-			mutateStatusFn: func(status *kubecontainer.PodStatus) {
-				status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
-				status.ContainerStatuses = status.ContainerStatuses[3:]
-				status.ContainerStatuses[0].ExitCode = 137
+		// For now the a2a9964a66ef481d10db3ffc15d4b26a234d0bdd fix isn't compatible with the sidecar patchset we keep in this fork. Comment out related tests.
+		/*
+			"Create a new pod sandbox if the pod sandbox is dead, init container failed and RestartPolicy == OnFailure": {
+				mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure },
+				mutateStatusFn: func(status *kubecontainer.PodStatus) {
+					status.SandboxStatuses[0].State = runtimeapi.PodSandboxState_SANDBOX_NOTREADY
+					status.ContainerStatuses = status.ContainerStatuses[3:]
+					status.ContainerStatuses[0].ExitCode = 137
+				},
+				actions: podActions{
+					KillPod:                  true,
+					CreateSandbox:            true,
+					SandboxID:                baseStatus.SandboxStatuses[0].Id,
+					Attempt:                  uint32(1),
+					NextInitContainerToStart: &basePod.Spec.InitContainers[0],
+					InitContainersToStart:    []int{0},
+					ContainersToStart:        []int{},
+					ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
+				},
 			},
-			actions: podActions{
-				KillPod:                  true,
-				CreateSandbox:            true,
-				SandboxID:                baseStatus.SandboxStatuses[0].Id,
-				Attempt:                  uint32(1),
-				NextInitContainerToStart: &basePod.Spec.InitContainers[0],
-				InitContainersToStart:    []int{0},
-				ContainersToStart:        []int{},
-				ContainersToKill:         getKillMapWithInitContainers(basePod, baseStatus, []int{}),
-			},
-		},
+		*/
 		"Kill pod and do not restart ephemeral container if the pod sandbox is dead": {
 			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {
@@ -2126,6 +2142,182 @@ func TestSyncPodWithSandboxAndDeletedPod(t *testing.T) {
 	result := m.SyncPod(context.Background(), pod, podStatus, []v1.Secret{}, backOff)
 	// This will return an error if the pod has _not_ been deleted.
 	assert.NoError(t, result.Error())
+}
+
+func TestComputePodActionsWithSidecar(t *testing.T) {
+	_, _, m, err := createTestRuntimeManager()
+	require.NoError(t, err)
+
+	// Createing a pair reference pod and status for the test cases to refer
+	// the specific fields.
+	basePod, baseStatus := makeBasePodAndStatusWithSidecar()
+	for desc, test := range map[string]struct {
+		mutatePodFn    func(*v1.Pod)
+		mutateStatusFn func(*kubecontainer.PodStatus)
+		actions        podActions
+	}{
+		"Start sidecar containers before non-sidecars when creating a new pod": {
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				// No container or sandbox exists.
+				status.SandboxStatuses = []*runtimeapi.PodSandboxStatus{}
+				status.ContainerStatuses = []*kubecontainer.Status{}
+			},
+			actions: podActions{
+				KillPod:           true,
+				CreateSandbox:     true,
+				Attempt:           uint32(0),
+				ContainersToStart: []int{1},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+		"Don't start non-sidecars until sidecars are ready": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{
+						Name: "foo1",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+					{
+						Name:  "foo2",
+						Ready: false,
+					},
+					{
+						Name: "foo3",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				for i := range status.ContainerStatuses {
+					if i == 1 {
+						continue
+					}
+					status.ContainerStatuses[i].State = ""
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				ContainersToStart: []int{},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+		"Start non-sidecars when sidecars are ready": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{
+						Name: "foo1",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+					{
+						Name:  "foo2",
+						Ready: true,
+					},
+					{
+						Name: "foo3",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				for i := range status.ContainerStatuses {
+					if i == 1 {
+						continue
+					}
+					status.ContainerStatuses[i].State = ""
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				ContainersToStart: []int{0, 2},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+		"Restart only sidecars while non-sidecars are waiting": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.RestartPolicy = v1.RestartPolicyAlways
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{
+						Name: "foo1",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+					{
+						Name:  "foo2",
+						Ready: false,
+					},
+					{
+						Name: "foo3",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				for i := range status.ContainerStatuses {
+					if i == 1 {
+						status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
+					}
+					status.ContainerStatuses[i].State = ""
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				ContainersToStart: []int{1},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+		"Restart running non-sidecars despite sidecar becoming not ready ": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.RestartPolicy = v1.RestartPolicyAlways
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{
+						Name: "foo1",
+					},
+					{
+						Name:  "foo2",
+						Ready: false,
+					},
+					{
+						Name: "foo3",
+					},
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				for i := range status.ContainerStatuses {
+					if i == 1 {
+						continue
+					}
+					status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				ContainersToStart: []int{0, 2},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+	} {
+		pod, status := makeBasePodAndStatusWithSidecar()
+		if test.mutatePodFn != nil {
+			test.mutatePodFn(pod)
+		}
+		if test.mutateStatusFn != nil {
+			test.mutateStatusFn(status)
+		}
+		ctx := context.Background()
+		actions := m.computePodActions(ctx, pod, status)
+		verifyActions(t, &test.actions, &actions, desc)
+	}
 }
 
 func makeBasePodAndStatusWithInitAndEphemeralContainers() (*v1.Pod, *kubecontainer.PodStatus) {

--- a/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_termination_order.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 
 	"k8s.io/kubernetes/pkg/kubelet/types"
 )
@@ -91,6 +92,71 @@ func newTerminationOrdering(pod *v1.Pod, runningContainerNames []string) *termin
 	return to
 }
 
+// lyftSidecarTerminationOrdering constructs a terminationOrdering based on the pod spec and the currently running containers.
+// lyftSidecar will always be last to terminate.
+// We assume that the nativeSidecar is always true when using the lyft Sidecar
+func lyftSidecarTerminationOrdering(pod *v1.Pod, runningContainerNames []string) *terminationOrdering {
+	to := &terminationOrdering{
+		prereqs:    map[string][]chan struct{}{},
+		terminated: map[string]chan struct{}{},
+	}
+
+	runningContainers := map[string]struct{}{}
+	for _, name := range runningContainerNames {
+		runningContainers[name] = struct{}{}
+	}
+
+	var mainContainerChannels []chan struct{}
+	var cleanContainerChannels []chan struct{}
+
+	// sidecar containers need to wait on main containers, so we create a channel per main container
+	// for them to wait on
+	for _, c := range pod.Spec.Containers {
+		channel := make(chan struct{})
+		to.terminated[c.Name] = channel
+		mainContainerChannels = append(mainContainerChannels, channel)
+
+		// If it's a lyft sidecar, we want to wait for all other containers to finish
+		if !isSidecar(pod, c.Name) {
+			cleanContainerChannels = append(cleanContainerChannels, channel)
+		} else {
+			to.prereqs[c.Name] = append(to.prereqs[c.Name], cleanContainerChannels...)
+		}
+		// if it's not a running container, pre-close the channel so nothing
+		// waits on it
+		if _, isRunning := runningContainers[c.Name]; !isRunning {
+			close(channel)
+		}
+	}
+
+	var previousSidecarName string
+	for i := range pod.Spec.InitContainers {
+		// get the init containers in reverse order
+		ic := pod.Spec.InitContainers[len(pod.Spec.InitContainers)-i-1]
+
+		channel := make(chan struct{})
+		to.terminated[ic.Name] = channel
+
+		// if it's not a running container, pre-close the channel so nothing
+		// waits on it
+		if _, isRunning := runningContainers[ic.Name]; !isRunning {
+			close(channel)
+		}
+
+		if types.IsRestartableInitContainer(&ic) {
+			// sidecars need to wait for all main containers to exit
+			to.prereqs[ic.Name] = append(to.prereqs[ic.Name], mainContainerChannels...)
+
+			// if there is a later sidecar, this container needs to wait for it to finish
+			if previousSidecarName != "" {
+				to.prereqs[ic.Name] = append(to.prereqs[ic.Name], to.terminated[previousSidecarName])
+			}
+			previousSidecarName = ic.Name
+		}
+	}
+	return to
+}
+
 // waitForTurn waits until it is time for the container with the specified name to begin terminating, up until
 // the specified grace period.  If gracePeriod = 0, there is no wait.
 func (o *terminationOrdering) waitForTurn(name string, gracePeriod int64) float64 {
@@ -107,10 +173,12 @@ func (o *terminationOrdering) waitForTurn(name string, gracePeriod int64) float6
 		case <-c:
 		case <-remainingGrace.C:
 			// grace period expired, so immediately exit
+			klog.V(3).InfoS("Sidecar container is ready to terminate, grace period is expired", "container", name, "gracePeriod", gracePeriod)
 			return time.Since(start).Seconds()
 		}
-	}
 
+	}
+	klog.V(3).InfoS("Container is ready to terminate", "container", name)
 	return time.Since(start).Seconds()
 }
 

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,7 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -43,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/status/state"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeutil "k8s.io/kubernetes/pkg/kubelet/util"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	statusutil "k8s.io/kubernetes/pkg/util/pod"
 )
 
@@ -1129,4 +1130,74 @@ func NeedToReconcilePodReadiness(pod *v1.Pod) bool {
 		return true
 	}
 	return false
+}
+
+// SidecarsStatus contains three bools, whether the pod has sidecars,
+// if the all the sidecars are ready and if the non sidecars are in a
+// waiting state.
+type SidecarsStatus struct {
+	SidecarsPresent   bool
+	SidecarsReady     bool
+	ContainersWaiting bool
+}
+
+// GetSidecarsStatus returns the SidecarsStatus for the given pod
+// We assume the worst: if we are unable to determine the status of all containers we make defensive assumptions that
+// there are sidecars, they are not ready, and that there are non-sidecars waiting. This is to prevent starting non-
+// -sidecars accidentally.
+func GetSidecarsStatus(pod *v1.Pod) SidecarsStatus {
+	var containerStatusesCopy []v1.ContainerStatus
+	if pod == nil {
+		klog.Infof("Pod was nil, returning sidecar status that prevents progress")
+		return SidecarsStatus{SidecarsPresent: true, SidecarsReady: false, ContainersWaiting: true}
+	}
+	if pod.Spec.Containers == nil {
+		klog.Infof("Pod %s: Containers was nil, returning sidecar status that prevents progress", format.Pod(pod))
+		return SidecarsStatus{SidecarsPresent: true, SidecarsReady: false, ContainersWaiting: true}
+	}
+	if pod.Status.ContainerStatuses == nil {
+		klog.Infof("Pod %s: ContainerStatuses was nil, doing best effort using spec", format.Pod(pod))
+	} else {
+		// Make a copy of ContainerStatuses to avoid having the carpet pulled from under our feet
+		containerStatusesCopy = make([]v1.ContainerStatus, len(pod.Status.ContainerStatuses))
+		copy(containerStatusesCopy, pod.Status.ContainerStatuses)
+	}
+
+	sidecarsStatus := SidecarsStatus{SidecarsPresent: false, SidecarsReady: true, ContainersWaiting: false}
+	for _, container := range pod.Spec.Containers {
+		foundStatus := false
+		isSidecar := false
+		if pod.Annotations[fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", container.Name)] == "Sidecar" {
+			isSidecar = true
+			sidecarsStatus.SidecarsPresent = true
+		}
+		for _, status := range containerStatusesCopy {
+			if status.Name == container.Name {
+				foundStatus = true
+				if isSidecar {
+					if !status.Ready {
+						klog.Infof("Pod %s: %s: sidecar not ready", format.Pod(pod), container.Name)
+						sidecarsStatus.SidecarsReady = false
+					} else {
+						klog.Infof("Pod %s: %s: sidecar is ready", format.Pod(pod), container.Name)
+					}
+				} else if status.State.Waiting != nil {
+					// check if non-sidecars have started
+					klog.Infof("Pod: %s: %s: non-sidecar waiting", format.Pod(pod), container.Name)
+					sidecarsStatus.ContainersWaiting = true
+				}
+				break
+			}
+		}
+		if !foundStatus {
+			if isSidecar {
+				klog.Infof("Pod %s: %s (sidecar): status not found, assuming not ready", format.Pod(pod), container.Name)
+				sidecarsStatus.SidecarsReady = false
+			} else {
+				klog.Infof("Pod: %s: %s (non-sidecar): status not found, assuming waiting", format.Pod(pod), container.Name)
+				sidecarsStatus.ContainersWaiting = true
+			}
+		}
+	}
+	return sidecarsStatus
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/binder.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder.go
@@ -222,8 +222,6 @@ type volumeBinder struct {
 	csiStorageCapacityLister storagelisters.CSIStorageCapacityLister
 }
 
-var _ SchedulerVolumeBinder = &volumeBinder{}
-
 // CapacityCheck contains additional parameters for NewVolumeBinder that
 // are only needed when checking volume sizes against available storage
 // capacity is desired.
@@ -265,7 +263,7 @@ func NewVolumeBinder(
 }
 
 // FindPodVolumes finds the matching PVs for PVCs and nodes to provision PVs
-// for the given pod and node. If the node does not fit, conflict reasons are
+// for the given pod and node. If the node does not fit, confilict reasons are
 // returned.
 func (b *volumeBinder) FindPodVolumes(logger klog.Logger, pod *v1.Pod, podVolumeClaims *PodVolumeClaims, node *v1.Node) (podVolumes *PodVolumes, reasons ConflictReasons, err error) {
 	podVolumes = &PodVolumes{}

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -340,6 +340,7 @@ func (pl *VolumeBinding) PreFilter(ctx context.Context, state *framework.CycleSt
 		status.AppendReason("pod has unbound immediate PersistentVolumeClaims")
 		return nil, status
 	}
+
 	state.Write(stateKey, &stateData{
 		podVolumesByNode: make(map[string]*PodVolumes),
 		podVolumeClaims: &PodVolumeClaims{

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -80,7 +80,6 @@ func TestVolumeBinding(t *testing.T) {
 		pvs                     []*v1.PersistentVolume
 		fts                     feature.Features
 		args                    *config.VolumeBindingArgs
-		wantPreFilterResult     *framework.PreFilterResult
 		wantPreFilterStatus     *framework.Status
 		wantStateAfterPreFilter *stateData
 		wantFilterStatus        []*framework.Status
@@ -795,10 +794,8 @@ func TestVolumeBinding(t *testing.T) {
 			state := framework.NewCycleState()
 
 			t.Logf("Verify: call PreFilter and check status")
-			gotPreFilterResult, gotPreFilterStatus := p.PreFilter(ctx, state, item.pod)
+			_, gotPreFilterStatus := p.PreFilter(ctx, state, item.pod)
 			assert.Equal(t, item.wantPreFilterStatus, gotPreFilterStatus)
-			assert.Equal(t, item.wantPreFilterResult, gotPreFilterResult)
-
 			if !gotPreFilterStatus.IsSuccess() {
 				// scheduler framework will skip Filter if PreFilter fails
 				return

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -503,6 +503,10 @@ func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watch
 		klog.V(2).Infof("processing %d initEvents of %s (%s) took %v", initEventCount, c.groupResource, c.identifier, processingTime)
 	}
 
+	// send bookmark after sending all events in cacheInterval for watchlist request
+	if cacheInterval.initialEventsEndBookmark != nil {
+		c.sendWatchCacheEvent(cacheInterval.initialEventsEndBookmark)
+	}
 	c.process(ctx, resourceVersion)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -653,6 +653,8 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 		return newErrWatcher(err), nil
 	}
 
+	c.setInitialEventsEndBookmarkIfRequested(cacheInterval, opts, c.watchCache.resourceVersion)
+
 	addedWatcher := false
 	func() {
 		c.Lock()
@@ -1437,6 +1439,26 @@ func (c *Cacher) waitUntilWatchCacheFreshAndForceAllEvents(ctx context.Context, 
 // Wait blocks until the cacher is Ready or Stopped, it returns an error if Stopped.
 func (c *Cacher) Wait(ctx context.Context) error {
 	return c.ready.wait(ctx)
+}
+
+// setInitialEventsEndBookmarkIfRequested sets initialEventsEndBookmark field in watchCacheInterval for watchlist request
+func (c *Cacher) setInitialEventsEndBookmarkIfRequested(cacheInterval *watchCacheInterval, opts storage.ListOptions, currentResourceVersion uint64) {
+	if opts.SendInitialEvents != nil && *opts.SendInitialEvents && opts.Predicate.AllowWatchBookmarks {
+		// We don't need to set the InitialEventsAnnotation for this bookmark event,
+		// because this will be automatically set during event conversion in cacheWatcher.convertToWatchEvent method
+		initialEventsEndBookmark := &watchCacheEvent{
+			Type:            watch.Bookmark,
+			Object:          c.newFunc(),
+			ResourceVersion: currentResourceVersion,
+		}
+
+		if err := c.versioner.UpdateObject(initialEventsEndBookmark.Object, initialEventsEndBookmark.ResourceVersion); err != nil {
+			klog.Errorf("failure to set resourceVersion to %d on initialEventsEndBookmark event %+v for watchlist request and wait for bookmark trigger to send", initialEventsEndBookmark.ResourceVersion, initialEventsEndBookmark.Object)
+			initialEventsEndBookmark = nil
+		}
+
+		cacheInterval.initialEventsEndBookmark = initialEventsEndBookmark
+	}
 }
 
 // errWatcher implements watch.Interface to return a single error

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/cacher/metrics"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
+	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	k8smetrics "k8s.io/component-base/metrics"
@@ -1161,6 +1162,106 @@ func TestCacherSendBookmarkEvents(t *testing.T) {
 
 	for _, tc := range testCases {
 		testCacherSendBookmarkEvents(t, tc.allowWatchBookmarks, tc.expectedBookmarks)
+	}
+}
+
+func TestInitialEventsEndBookmark(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
+	forceRequestWatchProgressSupport(t)
+
+	backingStorage := &dummyStorage{}
+	cacher, _, err := newTestCacher(backingStorage)
+	if err != nil {
+		t.Fatalf("Couldn't create cacher: %v", err)
+	}
+	defer cacher.Stop()
+
+	if !utilfeature.DefaultFeatureGate.Enabled(features.ResilientWatchCacheInitialization) {
+		if err := cacher.ready.wait(context.Background()); err != nil {
+			t.Fatalf("unexpected error waiting for the cache to be ready")
+		}
+	}
+
+	makePod := func(index uint64) *example.Pod {
+		return &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            fmt.Sprintf("pod-%d", index),
+				Namespace:       "ns",
+				ResourceVersion: fmt.Sprintf("%v", 100+index),
+			},
+		}
+	}
+
+	numberOfPods := 3
+	var expectedPodEvents []watch.Event
+	for i := 1; i <= numberOfPods; i++ {
+		pod := makePod(uint64(i))
+		if err := cacher.watchCache.Add(pod); err != nil {
+			t.Fatalf("failed to add a pod: %v", err)
+		}
+		expectedPodEvents = append(expectedPodEvents, watch.Event{Type: watch.Added, Object: pod})
+	}
+	var currentResourceVersion uint64 = 100 + 3
+
+	trueVal, falseVal := true, false
+
+	scenarios := []struct {
+		name                string
+		allowWatchBookmarks bool
+		sendInitialEvents   *bool
+	}{
+		{
+			name:                "allowWatchBookmarks=false, sendInitialEvents=false",
+			allowWatchBookmarks: false,
+			sendInitialEvents:   &falseVal,
+		},
+		{
+			name:                "allowWatchBookmarks=false, sendInitialEvents=true",
+			allowWatchBookmarks: false,
+			sendInitialEvents:   &trueVal,
+		},
+		{
+			name:                "allowWatchBookmarks=true, sendInitialEvents=true",
+			allowWatchBookmarks: true,
+			sendInitialEvents:   &trueVal,
+		},
+		{
+			name:                "allowWatchBookmarks=true, sendInitialEvents=false",
+			allowWatchBookmarks: true,
+			sendInitialEvents:   &falseVal,
+		},
+		{
+			name:                "allowWatchBookmarks=false, sendInitialEvents=nil",
+			allowWatchBookmarks: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			expectedWatchEvents := expectedPodEvents
+			if scenario.allowWatchBookmarks && scenario.sendInitialEvents != nil && *scenario.sendInitialEvents {
+				expectedWatchEvents = append(expectedWatchEvents, watch.Event{
+					Type: watch.Bookmark,
+					Object: &example.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							ResourceVersion: strconv.FormatUint(currentResourceVersion, 10),
+							Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
+						},
+					},
+				})
+			}
+
+			pred := storage.Everything
+			pred.AllowWatchBookmarks = scenario.allowWatchBookmarks
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+			w, err := cacher.Watch(ctx, "pods/ns", storage.ListOptions{ResourceVersion: "100", SendInitialEvents: scenario.sendInitialEvents, Predicate: pred})
+			if err != nil {
+				t.Fatalf("Failed to create watch: %v", err)
+			}
+			storagetesting.TestCheckResultsInStrictOrder(t, w, expectedWatchEvents)
+			storagetesting.TestCheckNoMoreResultsWithIgnoreFunc(t, w, nil)
+		})
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_interval.go
@@ -98,6 +98,9 @@ type watchCacheInterval struct {
 	// Given that indexer and indexValidator only read state, if
 	// possible, Locker obtained through RLocker() is provided.
 	lock sync.Locker
+
+	// initialEventsEndBookmark will be sent after sending all events in cacheInterval
+	initialEventsEndBookmark *watchCacheEvent
 }
 
 type attrFunc func(runtime.Object) (labels.Set, fields.Set, error)

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/watcher_tests.go
@@ -1478,7 +1478,7 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 			defer w.Stop()
 
 			// make sure we only get initial events
-			testCheckResultsInStrictOrder(t, w, scenario.expectedInitialEvents(createdPods))
+			TestCheckResultsInStrictOrder(t, w, scenario.expectedInitialEvents(createdPods))
 
 			// make sure that the actual bookmark has at least RV >= to the expected one
 			if scenario.expectedInitialEventsBookmarkWithMinimalRV != nil {
@@ -1512,8 +1512,9 @@ func RunWatchSemantics(ctx context.Context, t *testing.T, store storage.Interfac
 				require.NoError(t, err, "failed to add a pod: %v")
 				createdPods = append(createdPods, out)
 			}
-			testCheckResultsInStrictOrder(t, w, scenario.expectedEventsAfterEstablishingWatch(createdPods))
-			testCheckNoMoreResults(t, w)
+			ignoreEventsFn := func(event watch.Event) bool { return event.Type == watch.Bookmark }
+			testCheckResultWithIgnoreFunc(t, w, scenario.expectedEventsAfterEstablishingWatch(createdPods), ignoreEventsFn)
+			TestCheckNoMoreResultsWithIgnoreFunc(t, w, ignoreEventsFn)
 		})
 	}
 }
@@ -1567,8 +1568,63 @@ func RunWatchSemanticInitialEventsExtended(ctx context.Context, t *testing.T, st
 
 	// make sure we only get initial events from the first ns
 	// followed by the bookmark with the global RV
-	testCheckResultsInStrictOrder(t, w, expectedInitialEventsInStrictOrder(initialPods, otherNsPod.ResourceVersion))
-	testCheckNoMoreResults(t, w)
+	TestCheckResultsInStrictOrder(t, w, expectedInitialEventsInStrictOrder(initialPods, otherNsPod.ResourceVersion))
+	TestCheckNoMoreResultsWithIgnoreFunc(t, w, nil)
+}
+
+func RunWatchListMatchSingle(ctx context.Context, t *testing.T, store storage.Interface) {
+	trueVal := true
+	expectedInitialEventsInStrictOrder := func(initialPod *example.Pod, globalResourceVersion string) []watch.Event {
+		watchEvents := []watch.Event{}
+		watchEvents = append(watchEvents, watch.Event{Type: watch.Added, Object: initialPod})
+		watchEvents = append(watchEvents, watch.Event{Type: watch.Bookmark, Object: &example.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: globalResourceVersion,
+				Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
+			},
+		}})
+		return watchEvents
+	}
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.WatchList, true)
+
+	// add the pod for which the field selector will be constructed
+	ns := "ns-foo"
+	expectedPod := &example.Pod{}
+	initialPod := makePod("1")
+	initialPod.Namespace = ns
+	err := store.Create(ctx, computePodKey(initialPod), initialPod, expectedPod, 0)
+	require.NoError(t, err, "failed to add a pod: %v")
+
+	// add more pods that won't match the field selector
+	lastAddedPod := &example.Pod{}
+	for _, otherPod := range []*example.Pod{makePod("2"), makePod("3"), makePod("4"), makePod("5")} {
+		otherPod.Namespace = ns
+		err = store.Create(ctx, computePodKey(otherPod), otherPod, lastAddedPod, 0)
+		require.NoError(t, err, "failed to add a pod: %v")
+	}
+
+	opts := storage.ListOptions{
+		Predicate: storage.SelectionPredicate{
+			Label: labels.Everything(),
+			Field: fields.ParseSelectorOrDie("metadata.name=pod-1"),
+			GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+				pod := obj.(*example.Pod)
+				return nil, fields.Set{"metadata.name": pod.Name}, nil
+			},
+		},
+		Recursive: true,
+	}
+	opts.SendInitialEvents = &trueVal
+	opts.Predicate.AllowWatchBookmarks = true
+
+	w, err := store.Watch(context.Background(), "/pods", opts)
+	require.NoError(t, err, "failed to create watch: %v")
+	defer w.Stop()
+
+	// make sure we only get a single pod matching the field selector
+	// followed by the bookmark with the global RV
+	TestCheckResultsInStrictOrder(t, w, expectedInitialEventsInStrictOrder(expectedPod, lastAddedPod.ResourceVersion))
+	TestCheckNoMoreResultsWithIgnoreFunc(t, w, nil)
 }
 
 func makePod(namePrefix string) *example.Pod {

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -32,20 +32,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/util/retry"
-	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -225,196 +221,127 @@ var _ = SIGDescribe("Pods Extended", func() {
 		})
 	})
 
-	ginkgo.Describe("Pod Container lifecycle", func() {
-		var podClient *e2epod.PodClient
-		ginkgo.BeforeEach(func() {
-			podClient = e2epod.NewPodClient(f)
-		})
-
-		ginkgo.It("should not create extra sandbox if all containers are done", func(ctx context.Context) {
-			ginkgo.By("creating the pod that should always exit 0")
-
-			name := "pod-always-succeed" + string(uuid.NewUUID())
-			image := imageutils.GetE2EImage(imageutils.BusyBox)
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					InitContainers: []v1.Container{
-						{
-							Name:  "foo",
-							Image: image,
-							Command: []string{
-								"/bin/true",
-							},
-						},
-					},
-					Containers: []v1.Container{
-						{
-							Name:  "bar",
-							Image: image,
-							Command: []string{
-								"/bin/true",
-							},
-						},
-					},
-				},
-			}
-
-			ginkgo.By("submitting the pod to kubernetes")
-			createdPod := podClient.Create(ctx, pod)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	/*
+		// For now the a2a9964a66ef481d10db3ffc15d4b26a234d0bdd fix isn't compatible with
+		// the sidecar patchset we keep in this fork. Comment out related tests.
+		ginkgo.Describe("Pod Container lifecycle", func() {
+			var podClient *e2epod.PodClient
+			ginkgo.BeforeEach(func() {
+				podClient = e2epod.NewPodClient(f)
 			})
 
-			framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+			ginkgo.It("should not create extra sandbox if all containers are done", func() {
+				ginkgo.By("creating the pod that should always exit 0")
 
-			var eventList *v1.EventList
-			var err error
-			ginkgo.By("Getting events about the pod")
-			framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
-				selector := fields.Set{
-					"involvedObject.kind":      "Pod",
-					"involvedObject.uid":       string(createdPod.UID),
-					"involvedObject.namespace": f.Namespace.Name,
-					"source":                   "kubelet",
-				}.AsSelector().String()
-				options := metav1.ListOptions{FieldSelector: selector}
-				eventList, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, options)
-				if err != nil {
-					return false, err
-				}
-				if len(eventList.Items) > 0 {
-					return true, nil
-				}
-				return false, nil
-			}))
-
-			ginkgo.By("Checking events about the pod")
-			for _, event := range eventList.Items {
-				if event.Reason == events.SandboxChanged {
-					framework.Fail("Unexpected SandboxChanged event")
-				}
-			}
-		})
-
-		ginkgo.It("evicted pods should be terminal", func(ctx context.Context) {
-			ginkgo.By("creating the pod that should be evicted")
-
-			name := "pod-should-be-evicted" + string(uuid.NewUUID())
-			image := imageutils.GetE2EImage(imageutils.BusyBox)
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					Containers: []v1.Container{
-						{
-							Name:  "bar",
-							Image: image,
-							Command: []string{
-								"/bin/sh", "-c", "sleep 10; dd if=/dev/zero of=file bs=1M count=10; sleep 10000",
-							},
-							Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{
-									"ephemeral-storage": resource.MustParse("5Mi"),
+				name := "pod-always-succeed" + string(uuid.NewUUID())
+				image := imageutils.GetE2EImage(imageutils.BusyBox)
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+					Spec: v1.PodSpec{
+						RestartPolicy: v1.RestartPolicyOnFailure,
+						InitContainers: []v1.Container{
+							{
+								Name:  "foo",
+								Image: image,
+								Command: []string{
+									"/bin/true",
 								},
-							}},
-					},
-				},
-			}
-
-			ginkgo.By("submitting the pod to kubernetes")
-			podClient.Create(ctx, pod)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-			})
-
-			err := e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, pod.Name, "Evicted", f.Namespace.Name)
-			if err != nil {
-				framework.Failf("error waiting for pod to be evicted: %v", err)
-			}
-
-		})
-	})
-
-	ginkgo.Describe("Pod TerminationGracePeriodSeconds is negative", func() {
-		var podClient *e2epod.PodClient
-		ginkgo.BeforeEach(func() {
-			podClient = e2epod.NewPodClient(f)
-		})
-
-		ginkgo.It("pod with negative grace period", func(ctx context.Context) {
-			name := "pod-negative-grace-period" + string(uuid.NewUUID())
-			image := imageutils.GetE2EImage(imageutils.BusyBox)
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					Containers: []v1.Container{
-						{
-							Name:  "foo",
-							Image: image,
-							Command: []string{
-								"/bin/sh", "-c", "sleep 10000",
+							},
+						},
+						Containers: []v1.Container{
+							{
+								Name:  "bar",
+								Image: image,
+								Command: []string{
+									"/bin/true",
+								},
 							},
 						},
 					},
-					TerminationGracePeriodSeconds: utilpointer.Int64(-1),
-				},
-			}
+				}
 
-			ginkgo.By("submitting the pod to kubernetes")
-			podClient.Create(ctx, pod)
+				ginkgo.By("submitting the pod to kubernetes")
+				createdPod := podClient.Create(pod)
+				defer func() {
+					ginkgo.By("deleting the pod")
+					podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				}()
 
-			pod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err, "failed to query for pod")
+				framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name))
 
-			if pod.Spec.TerminationGracePeriodSeconds == nil {
-				framework.Failf("pod spec TerminationGracePeriodSeconds is nil")
-			}
+				var eventList *v1.EventList
+				var err error
+				ginkgo.By("Getting events about the pod")
+				framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
+					selector := fields.Set{
+						"involvedObject.kind":      "Pod",
+						"involvedObject.uid":       string(createdPod.UID),
+						"involvedObject.namespace": f.Namespace.Name,
+						"source":                   "kubelet",
+					}.AsSelector().String()
+					options := metav1.ListOptions{FieldSelector: selector}
+					eventList, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), options)
+					if err != nil {
+						return false, err
+					}
+					if len(eventList.Items) > 0 {
+						return true, nil
+					}
+					return false, nil
+				}))
 
-			if *pod.Spec.TerminationGracePeriodSeconds != 1 {
-				framework.Failf("pod spec TerminationGracePeriodSeconds is not 1: %d", *pod.Spec.TerminationGracePeriodSeconds)
-			}
-
-			// retry if the TerminationGracePeriodSeconds is overrided
-			// see more in https://github.com/kubernetes/kubernetes/pull/115606
-			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				pod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-				framework.ExpectNoError(err, "failed to query for pod")
-				ginkgo.By("updating the pod to have a negative TerminationGracePeriodSeconds")
-				pod.Spec.TerminationGracePeriodSeconds = utilpointer.Int64(-1)
-				_, err = podClient.PodInterface.Update(ctx, pod, metav1.UpdateOptions{})
-				return err
+				ginkgo.By("Checking events about the pod")
+				for _, event := range eventList.Items {
+					if event.Reason == events.SandboxChanged {
+						framework.Fail("Unexpected SandboxChanged event")
+					}
+				}
 			})
-			framework.ExpectNoError(err, "failed to update pod")
 
-			pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err, "failed to query for pod")
+			ginkgo.It("evicted pods should be terminal", func() {
+				ginkgo.By("creating the pod that should be evicted")
 
-			if pod.Spec.TerminationGracePeriodSeconds == nil {
-				framework.Failf("pod spec TerminationGracePeriodSeconds is nil")
-			}
+				name := "pod-should-be-evicted" + string(uuid.NewUUID())
+				image := imageutils.GetE2EImage(imageutils.BusyBox)
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+					Spec: v1.PodSpec{
+						RestartPolicy: v1.RestartPolicyOnFailure,
+						Containers: []v1.Container{
+							{
+								Name:  "bar",
+								Image: image,
+								Command: []string{
+									"/bin/sh", "-c", "sleep 10; dd if=/dev/zero of=file bs=1M count=10; sleep 10000",
+								},
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"ephemeral-storage": resource.MustParse("5Mi"),
+									},
+								}},
+						},
+					},
+				}
 
-			if *pod.Spec.TerminationGracePeriodSeconds != 1 {
-				framework.Failf("pod spec TerminationGracePeriodSeconds is not 1: %d", *pod.Spec.TerminationGracePeriodSeconds)
-			}
+				ginkgo.By("submitting the pod to kubernetes")
+				podClient.Create(pod)
+				defer func() {
+					ginkgo.By("deleting the pod")
+					podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				}()
 
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				err := e2epod.WaitForPodTerminatedInNamespace(f.ClientSet, pod.Name, "Evicted", f.Namespace.Name)
+				if err != nil {
+					framework.Failf("error waiting for pod to be evicted: %v", err)
+				}
+
 			})
 		})
-	})
-
+	*/
 })
 
 func createAndTestPodRepeatedly(ctx context.Context, workers, iterations int, scenario podScenario, podClient v1core.PodInterface) {

--- a/test/integration/volumescheduling/volume_binding_test.go
+++ b/test/integration/volumescheduling/volume_binding_test.go
@@ -671,7 +671,7 @@ func TestPVAffinityConflict(t *testing.T) {
 		if _, err := config.client.CoreV1().Pods(config.ns).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
 			t.Fatalf("Failed to create Pod %q: %v", pod.Name, err)
 		}
-		// Give time to scheduler to attempt to schedule pod
+		// Give time to shceduler to attempt to schedule pod
 		if err := waitForPodUnschedulable(config.client, pod); err != nil {
 			t.Errorf("Failed as Pod %s was not unschedulable: %v", pod.Name, err)
 		}
@@ -686,8 +686,8 @@ func TestPVAffinityConflict(t *testing.T) {
 		if strings.Compare(p.Status.Conditions[0].Reason, "Unschedulable") != 0 {
 			t.Fatalf("Failed as Pod %s reason was: %s but expected: Unschedulable", podName, p.Status.Conditions[0].Reason)
 		}
-		if !strings.Contains(p.Status.Conditions[0].Message, "node(s) didn't match Pod's node affinity") {
-			t.Fatalf("Failed as Pod's %s failure message does not contain expected message: node(s) didn't match Pod's node affinity. Got message %q", podName, p.Status.Conditions[0].Message)
+		if !strings.Contains(p.Status.Conditions[0].Message, "node(s) didn't match Pod's node affinity") || !strings.Contains(p.Status.Conditions[0].Message, "node(s) had volume node affinity conflict") {
+			t.Fatalf("Failed as Pod's %s failure message does not contain expected message: node(s) didn't match Pod's node affinity, node(s) had volume node affinity conflict. Got message %q", podName, p.Status.Conditions[0].Message)
 		}
 		// Deleting test pod
 		if err := config.client.CoreV1().Pods(config.ns).Delete(context.TODO(), podName, metav1.DeleteOptions{}); err != nil {


### PR DESCRIPTION
- Similarly to https://github.com/DataDog/kubernetes/pull/91, squashed all github action changes in one commit https://github.com/DataDog/kubernetes/commit/2d86a096993fa76c8d48730d105d164393ec3af2
- Need to keep https://github.com/DataDog/kubernetes/commit/eb6ec31c05a3510b870c3a1deee0cd913ebd170a as https://github.com/kubernetes/kubernetes/pull/125398/commits/4ef58b287747f03ad8f6270bb7cabba1283836d9 only appears in 1.32
- Kept https://github.com/DataDog/kubernetes/commit/54cedb9303e55750d7832935f701b573b140ab80 as we maintain it in 1.31, see https://github.com/DataDog/kubernetes/pull/85
- Need to keep https://github.com/DataDog/kubernetes/commit/e3561514397866e174ea0b82b1086e1a254886ae as https://github.com/kubernetes/kubernetes/pull/127012/commits/723920253349ee3c272c5b5a77e9d19548c1533c only appears in 1.32
- Similarly to https://github.com/DataDog/kubernetes/pull/91, squashed all fips changes in one commit https://github.com/DataDog/kubernetes/commit/751b9d2cffcf673e614e46bd606d616efac31b12