### PR TITLE
[client-go #1415] Use transformer from provided store within internal stores in reflector to limit memory usage bursts

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -303,6 +303,11 @@ func (f *DeltaFIFO) KeyOf(obj interface{}) (string, error) {
 	return f.keyFunc(obj)
 }
 
+// Transformer implements the TransformingStore interface.
+func (f *DeltaFIFO) Transformer() TransformFunc {
+	return f.transformer
+}
+
 // HasSynced returns true if an Add/Update/Delete/AddIfNotPresent are called first,
 // or the first batch of items inserted by Replace() has been popped.
 func (f *DeltaFIFO) HasSynced() bool {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -77,6 +77,12 @@ type ReflectorStore interface {
 	Resync() error
 }
 
+// TransformingStore is an optional interface that can be implemented by the provided store.
+// If implemented on the provided store reflector will use the same transformer in its internal stores.
+type TransformingStore interface {
+	Transformer() TransformFunc
+}
+
 // Reflector watches a specified resource and causes all changes to be reflected in the given store.
 type Reflector struct {
 	// name identifies this reflector. By default, it will be a file:line if possible.
@@ -714,6 +720,11 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 		return false
 	}
 
+	storeOpts := []StoreOption{}
+	if tr, ok := r.store.(TransformingStore); ok && tr.Transformer() != nil {
+		storeOpts = append(storeOpts, WithTransformer(tr.Transformer()))
+	}
+
 	initTrace := trace.New("Reflector WatchList", trace.Field{Key: "name", Value: r.name})
 	defer initTrace.LogIfLong(10 * time.Second)
 	for {
@@ -725,7 +736,7 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 
 		resourceVersion = ""
 		lastKnownRV := r.rewatchResourceVersion()
-		temporaryStore = NewStore(DeletionHandlingMetaNamespaceKeyFunc)
+		temporaryStore = NewStore(DeletionHandlingMetaNamespaceKeyFunc, storeOpts...)
 		// TODO(#115478): large "list", slow clients, slow network, p&f
 		//  might slow down streaming and eventually fail.
 		//  maybe in such a case we should retry with an increased timeout?

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/ptr"
 )
 
 var nevererrc chan error
@@ -1913,10 +1914,117 @@ func TestReflectorReplacesStoreOnUnsafeDelete(t *testing.T) {
 	}
 }
 
+func TestReflectorRespectStoreTransformer(t *testing.T) {
+	mkPod := func(id string, rv string) *v1.Pod {
+		return &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: id, ResourceVersion: rv},
+			Spec: v1.PodSpec{
+				Hostname: "test",
+			},
+		}
+	}
+
+	preExisting1 := mkPod("foo-1", "1")
+	preExisting2 := mkPod("foo-2", "2")
+	pod3 := mkPod("foo-3", "3")
+
+	lastExpectedRV := "3"
+	events := []watch.Event{
+		{Type: watch.Added, Object: preExisting1},
+		{Type: watch.Added, Object: preExisting2},
+		{Type: watch.Bookmark, Object: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				ResourceVersion: lastExpectedRV,
+				Annotations: map[string]string{
+					metav1.InitialEventsAnnotationKey: "true",
+				},
+			},
+		}},
+		{Type: watch.Added, Object: pod3},
+	}
+
+	s := NewFIFO(MetaNamespaceKeyFunc)
+	var replaceInvoked atomic.Int32
+	store := &fakeStore{
+		Store: s,
+		beforeReplace: func(list []interface{}, rv string) {
+			replaceInvoked.Add(1)
+			// Only two pods are present at the point when Replace is called.
+			if len(list) != 2 {
+				t.Errorf("unexpected nb of objects: expected 2 received %d", len(list))
+			}
+			for _, obj := range list {
+				cast := obj.(*v1.Pod)
+				if cast.Spec.Hostname != "transformed" {
+					t.Error("Object was not transformed prior to replacement")
+				}
+			}
+		},
+		afterReplace: func(rv string, err error) {},
+		transformer: func(i interface{}) (interface{}, error) {
+			cast := i.(*v1.Pod)
+			cast.Spec.Hostname = "transformed"
+			return cast, nil
+		},
+	}
+
+	var once sync.Once
+	lw := &ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			fw := watch.NewFake()
+			go func() {
+				once.Do(func() {
+					for _, e := range events {
+						fw.Action(e.Type, e.Object)
+					}
+				})
+			}()
+			return fw, nil
+		},
+		// ListFunc should never be used in WatchList mode
+		ListFunc: nil,
+	}
+
+	r := NewReflector(lw, &v1.Pod{}, store, 0)
+	r.UseWatchList = ptr.To(true)
+	doneCh, stopCh := make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(doneCh)
+		//nolint:logcheck // Intentionally uses the old API.
+		r.Run(stopCh)
+	}()
+
+	// wait for the RV to sync to the version returned by the final list
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (done bool, err error) {
+		if rv := r.LastSyncResourceVersion(); rv == lastExpectedRV {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("reflector never caught up with expected revision: %q, err: %v", lastExpectedRV, err)
+	}
+
+	if want, got := lastExpectedRV, r.LastSyncResourceVersion(); want != got {
+		t.Errorf("expected LastSyncResourceVersion to be %q, but got: %q", want, got)
+	}
+	if want, got := 1, int(replaceInvoked.Load()); want != got {
+		t.Errorf("expected replace to be invoked %d times, but got: %d", want, got)
+	}
+
+	close(stopCh)
+	select {
+	case <-doneCh:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Errorf("timed out waiting for Run to return")
+	}
+}
+
 type fakeStore struct {
 	Store
 	beforeReplace func(list []interface{}, s string)
 	afterReplace  func(rv string, err error)
+	transformer   TransformFunc
 }
 
 func (f *fakeStore) Replace(list []interface{}, rv string) error {
@@ -1924,6 +2032,10 @@ func (f *fakeStore) Replace(list []interface{}, rv string) error {
 	err := f.Store.Replace(list, rv)
 	f.afterReplace(rv, err)
 	return err
+}
+
+func (f *fakeStore) Transformer() TransformFunc {
+	return f.transformer
 }
 
 func BenchmarkExtractList(b *testing.B) {

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -161,6 +161,8 @@ type cache struct {
 	// keyFunc is used to make the key for objects stored in and retrieved from items, and
 	// should be deterministic.
 	keyFunc KeyFunc
+	// Called with every object if non-nil.
+	transformer TransformFunc
 }
 
 var _ Store = &cache{}
@@ -171,6 +173,12 @@ func (c *cache) Add(obj interface{}) error {
 	if err != nil {
 		return KeyError{obj, err}
 	}
+	if c.transformer != nil {
+		obj, err = c.transformer(obj)
+		if err != nil {
+			return fmt.Errorf("transforming: %w", err)
+		}
+	}
 	c.cacheStorage.Add(key, obj)
 	return nil
 }
@@ -180,6 +188,12 @@ func (c *cache) Update(obj interface{}) error {
 	key, err := c.keyFunc(obj)
 	if err != nil {
 		return KeyError{obj, err}
+	}
+	if c.transformer != nil {
+		obj, err = c.transformer(obj)
+		if err != nil {
+			return fmt.Errorf("transforming: %w", err)
+		}
 	}
 	c.cacheStorage.Update(key, obj)
 	return nil
@@ -267,6 +281,13 @@ func (c *cache) Replace(list []interface{}, resourceVersion string) error {
 		if err != nil {
 			return KeyError{item, err}
 		}
+
+		if c.transformer != nil {
+			item, err = c.transformer(item)
+			if err != nil {
+				return fmt.Errorf("transforming: %w", err)
+			}
+		}
 		items[key] = item
 	}
 	c.cacheStorage.Replace(items, resourceVersion)
@@ -278,12 +299,24 @@ func (c *cache) Resync() error {
 	return nil
 }
 
+type StoreOption = func(*cache)
+
+func WithTransformer(transformer TransformFunc) StoreOption {
+	return func(c *cache) {
+		c.transformer = transformer
+	}
+}
+
 // NewStore returns a Store implemented simply with a map and a lock.
-func NewStore(keyFunc KeyFunc) Store {
-	return &cache{
+func NewStore(keyFunc KeyFunc, opts ...StoreOption) Store {
+	c := &cache{
 		cacheStorage: NewThreadSafeStore(Indexers{}, Indices{}),
 		keyFunc:      keyFunc,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // NewIndexer returns an Indexer implemented simply with a map and a lock.

--- a/staging/src/k8s.io/client-go/tools/cache/store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store_test.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -141,6 +142,21 @@ type testStoreObject struct {
 
 func TestCache(t *testing.T) {
 	doTestStore(t, NewStore(testStoreKeyFunc))
+}
+
+func TestCacheWithTransformer(t *testing.T) {
+	informerCalled := &atomic.Bool{}
+	doTestStore(t, NewStore(testStoreKeyFunc, WithTransformer(func(i interface{}) (interface{}, error) {
+		informerCalled.Store(true)
+		obj, ok := i.(testStoreObject)
+		if !ok {
+			return nil, errors.New("wrong object type")
+		}
+		return obj, nil
+	})))
+	if !informerCalled.Load() {
+		t.Error("informer was not called")
+	}
 }
 
 func TestFIFOCache(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR updates `client-go`. It ensures the reflector used in SharedInformers does not keep a full list of objects retrieved through `watchList` **without** transformation prior to passing the objects one at a time to the underlying Store (which may have a transformer defined.
Without this change, the informer ends up holding a full copy of unmutated objects in memory prior to being passed to the transformer, greatly limiting its value as a way to avoid large memory allocations. In our example (referring to the issue), we gain more than one OOM in the memory we need to provide a controller running a pod informer. 

To not change the semantic of `watchList` (especially on not altering the backing store if the watch does not conclude), the code still uses a temporary store but applies the same transformer as the provided Store if applicable. This has the side effect of potentially running the transformer twice, but this side effect is already specifically mentioned within the `TransformFunc` comment, and users will not be impacted if not explicitly activating the `WatchList` feature flag in the client

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes/client-go/issues/1415

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
 - Ensure objects are transformed prior to storage in SharedInformers if a transformer is provided and `WatchList` is activated
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
