### PR TITLE
Cherry Pick #135087

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -118,6 +118,7 @@ require (
 	k8s.io/sample-apiserver v0.0.0
 	k8s.io/system-validators v1.10.1
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
+	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8
 	sigs.k8s.io/knftables v0.0.17
 	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0
@@ -217,7 +218,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250604051438-85fd79dbfd9f // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
-	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/kustomize/api v0.20.1 // indirect
 	sigs.k8s.io/kustomize/kustomize/v5 v5.7.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.20.1 // indirect

--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -111,26 +111,8 @@ func SortControllerRevisions(revisions []*apps.ControllerRevision) {
 // EqualRevision returns true if lhs and rhs are either both nil, or both point to non-nil ControllerRevisions that
 // contain semantically equivalent data. Otherwise this method returns false.
 func EqualRevision(lhs *apps.ControllerRevision, rhs *apps.ControllerRevision) bool {
-	var lhsHash, rhsHash *uint32
 	if lhs == nil || rhs == nil {
 		return lhs == rhs
-	}
-	if hs, found := lhs.Labels[ControllerRevisionHashLabel]; found {
-		hash, err := strconv.ParseInt(hs, 10, 32)
-		if err == nil {
-			lhsHash = new(uint32)
-			*lhsHash = uint32(hash)
-		}
-	}
-	if hs, found := rhs.Labels[ControllerRevisionHashLabel]; found {
-		hash, err := strconv.ParseInt(hs, 10, 32)
-		if err == nil {
-			rhsHash = new(uint32)
-			*rhsHash = uint32(hash)
-		}
-	}
-	if lhsHash != nil && rhsHash != nil && *lhsHash != *rhsHash {
-		return false
 	}
 	return bytes.Equal(lhs.Data.Raw, rhs.Data.Raw) && apiequality.Semantic.DeepEqual(lhs.Data.Object, rhs.Data.Object)
 }

--- a/pkg/controller/statefulset/stateful_set_compatibility_test.go
+++ b/pkg/controller/statefulset/stateful_set_compatibility_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statefulset
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/json"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+)
+
+func TestStatefulSetCompatibility(t *testing.T) {
+	set133 := &appsv1.StatefulSet{}
+	set134 := &appsv1.StatefulSet{}
+	rev133 := &appsv1.ControllerRevision{}
+	rev134 := &appsv1.ControllerRevision{}
+	load(t, "compatibility_set_1.33.0.json", set133)
+	load(t, "compatibility_set_1.34.0.json", set134)
+	load(t, "compatibility_revision_1.33.0.json", rev133)
+	load(t, "compatibility_revision_1.34.0.json", rev134)
+
+	testcases := []struct {
+		name      string
+		set       *appsv1.StatefulSet
+		revisions []*appsv1.ControllerRevision
+	}{
+		{
+			name:      "1.33 set, 1.33 rev",
+			set:       set133.DeepCopy(),
+			revisions: []*appsv1.ControllerRevision{rev133.DeepCopy()},
+		},
+		{
+			name:      "1.34 set, 1.34 rev",
+			set:       set134.DeepCopy(),
+			revisions: []*appsv1.ControllerRevision{rev134.DeepCopy()},
+		},
+		{
+			name:      "1.34 set, 1.33+1.34 rev",
+			set:       set134.DeepCopy(),
+			revisions: []*appsv1.ControllerRevision{rev133.DeepCopy(), rev134.DeepCopy()},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			latestRev := tc.revisions[len(tc.revisions)-1]
+			client := fake.NewClientset(tc.set)
+			_, _, ssc := setupController(client)
+			currentRev, updateRev, _, err := ssc.(*defaultStatefulSetControl).getStatefulSetRevisions(tc.set, tc.revisions)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(currentRev, latestRev) {
+				t.Fatalf("expected no change from latestRev, got %s", cmp.Diff(latestRev, currentRev))
+			}
+			if !reflect.DeepEqual(updateRev, latestRev) {
+				t.Fatalf("expected no change from latestRev, got %s", cmp.Diff(latestRev, updateRev))
+			}
+		})
+	}
+}
+
+func BenchmarkStatefulSetCompatibility(b *testing.B) {
+	set133 := &appsv1.StatefulSet{}
+	set134 := &appsv1.StatefulSet{}
+	rev133 := &appsv1.ControllerRevision{}
+	rev134 := &appsv1.ControllerRevision{}
+	load(b, "compatibility_set_1.33.0.json", set133)
+	load(b, "compatibility_set_1.34.0.json", set134)
+	load(b, "compatibility_revision_1.33.0.json", rev133)
+	load(b, "compatibility_revision_1.34.0.json", rev134)
+
+	testcases := []struct {
+		name      string
+		set       *appsv1.StatefulSet
+		revisions []*appsv1.ControllerRevision
+	}{
+		{
+			name:      "1.33 set, 1.33 rev",
+			set:       set133.DeepCopy(),
+			revisions: []*appsv1.ControllerRevision{rev133.DeepCopy()},
+		},
+		{
+			name:      "1.34 set, 1.34 rev",
+			set:       set134.DeepCopy(),
+			revisions: []*appsv1.ControllerRevision{rev134.DeepCopy()},
+		},
+		{
+			name:      "1.34 set, 1.33+1.34 rev",
+			set:       set134.DeepCopy(),
+			revisions: []*appsv1.ControllerRevision{rev133.DeepCopy(), rev134.DeepCopy()},
+		},
+	}
+
+	for _, tc := range testcases {
+		b.Run(tc.name, func(b *testing.B) {
+			latestRev := tc.revisions[len(tc.revisions)-1]
+			client := fake.NewClientset(tc.set)
+			_, _, ssc := setupController(client)
+			for i := 0; i < b.N; i++ {
+				currentRev, updateRev, _, err := ssc.(*defaultStatefulSetControl).getStatefulSetRevisions(tc.set, tc.revisions)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if !reflect.DeepEqual(currentRev, latestRev) {
+					b.Fatalf("expected no change from latestRev, got %s", cmp.Diff(latestRev, currentRev))
+				}
+				if !reflect.DeepEqual(updateRev, latestRev) {
+					b.Fatalf("expected no change from latestRev, got %s", cmp.Diff(latestRev, updateRev))
+				}
+			}
+		})
+	}
+}
+
+func load(t testing.TB, filename string, object runtime.Object) {
+	data, err := os.ReadFile("testdata/" + filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strictErrs, err := json.UnmarshalStrict(data, object); err != nil {
+		t.Fatal(err)
+	} else if len(strictErrs) > 0 {
+		t.Fatal(strictErrs)
+	}
+	// apply defaulting just as if it was read from etcd
+	legacyscheme.Scheme.Default(object)
+}

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/utils/lru"
 	"k8s.io/utils/ptr"
 
 	apps "k8s.io/api/apps/v1"
@@ -883,7 +884,7 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		spc := NewStatefulPodControlFromManager(newFakeObjectManager(informerFactory), &noopRecorder{})
 		ssu := newFakeStatefulSetStatusUpdater(informerFactory.Apps().V1().StatefulSets())
-		ssc := defaultStatefulSetControl{spc, ssu, history.NewFakeHistory(informerFactory.Apps().V1().ControllerRevisions())}
+		ssc := defaultStatefulSetControl{spc, ssu, history.NewFakeHistory(informerFactory.Apps().V1().ControllerRevisions()), lru.New(maxRevisionEqualityCacheEntries)}
 
 		stop := make(chan struct{})
 		defer close(stop)

--- a/pkg/controller/statefulset/testdata/compatibility_revision_1.33.0.json
+++ b/pkg/controller/statefulset/testdata/compatibility_revision_1.33.0.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion":"apps/v1",
+  "kind":"ControllerRevision",
+  "metadata":{
+    "creationTimestamp":"2025-10-31T18:19:02Z",
+    "labels":{
+      "app":"foo",
+      "controller.kubernetes.io/hash":"c77f6d978"
+    },
+    "name":"test-c77f6d978",
+    "namespace":"default",
+    "ownerReferences":[{
+      "apiVersion":"apps/v1",
+      "blockOwnerDeletion":true,
+      "controller":true,
+      "kind":"StatefulSet",
+      "name":"test",
+      "uid":"ec335e25-1045-4216-8634-50cfbe05f3d6"
+    }],
+    "resourceVersion":"2209",
+    "uid":"af6e1945-ed14-4d1a-b420-813aa683a0fd"
+  },
+  "data":{"spec":{"template":{"$patch":"replace","metadata":{"annotations":{"test":"value"},"creationTimestamp":null,"labels":{"app":"foo"}},"spec":{"containers":[{"image":"test","imagePullPolicy":"Always","name":"test","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File"}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30}}}},
+  "revision":1
+}

--- a/pkg/controller/statefulset/testdata/compatibility_revision_1.34.0.json
+++ b/pkg/controller/statefulset/testdata/compatibility_revision_1.34.0.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion":"apps/v1",
+  "kind":"ControllerRevision",
+  "metadata":{
+    "creationTimestamp":"2025-11-03T19:46:23Z",
+    "labels":{
+      "app":"foo",
+      "controller.kubernetes.io/hash":"776999688b"
+    },
+    "name":"test-776999688b",
+    "namespace":"default",
+    "ownerReferences":[{
+      "apiVersion":"apps/v1",
+      "blockOwnerDeletion":true,
+      "controller":true,
+      "kind":"StatefulSet",
+      "name":"test",
+      "uid":"ec335e25-1045-4216-8634-50cfbe05f3d6"
+    }],
+    "resourceVersion":"16318",
+    "uid":"47df387b-5f17-40b6-9964-4c43cf6ad5d1"
+  },
+  "data":{"spec":{"template":{"$patch":"replace","metadata":{"annotations":{"test":"value"},"labels":{"app":"foo"}},"spec":{"containers":[{"image":"test","imagePullPolicy":"Always","name":"test","resources":{},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File"}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","schedulerName":"default-scheduler","securityContext":{},"terminationGracePeriodSeconds":30}}}},
+  "revision":2
+}

--- a/pkg/controller/statefulset/testdata/compatibility_set_1.33.0.json
+++ b/pkg/controller/statefulset/testdata/compatibility_set_1.33.0.json
@@ -1,0 +1,104 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "creationTimestamp": "2025-10-31T18:19:02Z",
+    "generation": 1,
+    "labels": {
+      "sslabel": "value"
+    },
+    "name": "test",
+    "namespace": "default",
+    "resourceVersion": "2219",
+    "uid": "ec335e25-1045-4216-8634-50cfbe05f3d6"
+  },
+  "spec": {
+    "persistentVolumeClaimRetentionPolicy": {
+      "whenDeleted": "Retain",
+      "whenScaled": "Retain"
+    },
+    "podManagementPolicy": "OrderedReady",
+    "replicas": 1,
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "app": "foo"
+      }
+    },
+    "serviceName": "",
+    "template": {
+      "metadata": {
+        "annotations": {
+          "test": "value"
+        },
+        "creationTimestamp": null,
+        "labels": {
+          "app": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "test",
+            "imagePullPolicy": "Always",
+            "name": "test",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    },
+    "updateStrategy": {
+      "rollingUpdate": {
+        "partition": 0
+      },
+      "type": "RollingUpdate"
+    },
+    "volumeClaimTemplates": [
+      {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {
+          "annotations": {
+            "key": "value"
+          },
+          "creationTimestamp": null,
+          "labels": {
+            "key": "value"
+          },
+          "name": "test"
+        },
+        "spec": {
+          "accessModes": [
+            "ReadWriteOnce"
+          ],
+          "resources": {
+            "requests": {
+              "storage": "1Gi"
+            }
+          },
+          "volumeMode": "Filesystem"
+        },
+        "status": {
+          "phase": "Pending"
+        }
+      }
+    ]
+  },
+  "status": {
+    "availableReplicas": 1,
+    "collisionCount": 0,
+    "currentReplicas": 1,
+    "currentRevision": "test-c77f6d978",
+    "observedGeneration": 1,
+    "replicas": 1,
+    "updateRevision": "test-c77f6d978",
+    "updatedReplicas": 1
+  }
+}

--- a/pkg/controller/statefulset/testdata/compatibility_set_1.34.0.json
+++ b/pkg/controller/statefulset/testdata/compatibility_set_1.34.0.json
@@ -1,0 +1,102 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "StatefulSet",
+  "metadata": {
+    "creationTimestamp": "2025-10-31T18:19:02Z",
+    "generation": 1,
+    "labels": {
+      "sslabel": "value"
+    },
+    "name": "test",
+    "namespace": "default",
+    "resourceVersion": "16319",
+    "uid": "ec335e25-1045-4216-8634-50cfbe05f3d6"
+  },
+  "spec": {
+    "persistentVolumeClaimRetentionPolicy": {
+      "whenDeleted": "Retain",
+      "whenScaled": "Retain"
+    },
+    "podManagementPolicy": "OrderedReady",
+    "replicas": 1,
+    "revisionHistoryLimit": 10,
+    "selector": {
+      "matchLabels": {
+        "app": "foo"
+      }
+    },
+    "serviceName": "",
+    "template": {
+      "metadata": {
+        "annotations": {
+          "test": "value"
+        },
+        "labels": {
+          "app": "foo"
+        }
+      },
+      "spec": {
+        "containers": [
+          {
+            "image": "test",
+            "imagePullPolicy": "Always",
+            "name": "test",
+            "resources": {},
+            "terminationMessagePath": "/dev/termination-log",
+            "terminationMessagePolicy": "File"
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "schedulerName": "default-scheduler",
+        "securityContext": {},
+        "terminationGracePeriodSeconds": 30
+      }
+    },
+    "updateStrategy": {
+      "rollingUpdate": {
+        "partition": 0
+      },
+      "type": "RollingUpdate"
+    },
+    "volumeClaimTemplates": [
+      {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {
+          "annotations": {
+            "key": "value"
+          },
+          "labels": {
+            "key": "value"
+          },
+          "name": "test"
+        },
+        "spec": {
+          "accessModes": [
+            "ReadWriteOnce"
+          ],
+          "resources": {
+            "requests": {
+              "storage": "1Gi"
+            }
+          },
+          "volumeMode": "Filesystem"
+        },
+        "status": {
+          "phase": "Pending"
+        }
+      }
+    ]
+  },
+  "status": {
+    "availableReplicas": 1,
+    "collisionCount": 0,
+    "currentReplicas": 1,
+    "currentRevision": "test-776999688b",
+    "observedGeneration": 1,
+    "replicas": 1,
+    "updateRevision": "test-776999688b",
+    "updatedReplicas": 1
+  }
+}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -941,6 +941,12 @@ const (
 	// Enables policies controlling deletion of PVCs created by a StatefulSet.
 	StatefulSetAutoDeletePVC featuregate.Feature = "StatefulSetAutoDeletePVC"
 
+	// owner: @liggitt
+	//
+	// Mitigates spurious statefulset rollouts due to controller revision comparison mismatches
+	// which are not semantically significant (e.g. serialization differences or missing defaulted fields).
+	StatefulSetSemanticRevisionComparison = "StatefulSetSemanticRevisionComparison"
+
 	// owner: @cupnes
 	// kep: https://kep.k8s.io/4049
 	//
@@ -1753,6 +1759,12 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.23"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.27"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.32"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.32, remove in 1.35
+	},
+
+	StatefulSetSemanticRevisionComparison: {
+		// This is a mitigation for a 1.34 regression due to serialization differences that cannot be feature-gated,
+		// so this mitigation should not auto-disable even if emulating versions prior to 1.34 with --emulation-version.
+		{Version: version.MustParse("1.0"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	StorageCapacityScoring: {

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -1633,6 +1633,12 @@
     lockToDefault: true
     preRelease: GA
     version: "1.32"
+- name: StatefulSetSemanticRevisionComparison
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "1.0"
 - name: StorageCapacityScoring
   versionedSpecs:
   - default: false


### PR DESCRIPTION
This is a copy of the https://github.com/kubernetes/kubernetes/pull/135087 cherry pick on the upstream repo.
It's coming from https://github.com/kubernetes/kubernetes/pull/135017
It fixes https://github.com/kubernetes/kubernetes/issues/134773 that causes a bit of a mayhem in staging last week. 
Once we merge / tag / ship it , we should be good to resume existing cluster upgrades.