### PR TITLE
admission/vap: invalidate RESTMapper cache on paramKind miss

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -407,6 +407,7 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 		// return below, preserving the existing rate-limited retry behavior.
 		type resettable interface{ Reset() }
 		if r, ok := s.restMapper.(resettable); ok {
+			klog.V(4).Infof("RESTMapper cache miss for paramKind %v; invalidating and retrying", *paramSource)
 			r.Reset()
 			mapping, err = s.restMapper.RESTMapping(schema.GroupKind{
 				Group: paramSource.Group,

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -395,8 +395,29 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 	}, paramSource.Version)
 
 	if err != nil {
-		// Failed to resolve. Return error so we retry again (rate limited)
-		// Save a record of this definition with an evaluator that unconditionally
+		// RESTMapper cache miss. The CRD may exist but not yet be reflected in
+		// the discovery cache (~30s refresh cycle). This happens after an apiserver
+		// restart if the CRD controller has not finished re-registering the API
+		// group before the discovery cache was last populated. In that case the
+		// cache is marked "fresh" and the built-in retry inside
+		// DeferredDiscoveryRESTMapper does not fire.
+		//
+		// Invalidate the cache and retry once. If the CRD genuinely does not
+		// exist, the second call will also fail and we fall through to the error
+		// return below, preserving the existing rate-limited retry behavior.
+		type resettable interface{ Reset() }
+		if r, ok := s.restMapper.(resettable); ok {
+			r.Reset()
+			mapping, err = s.restMapper.RESTMapping(schema.GroupKind{
+				Group: paramSource.Group,
+				Kind:  paramSource.Kind,
+			}, paramSource.Version)
+		}
+	}
+
+	if err != nil {
+		// Failed to resolve after cache invalidation. Return error so we retry
+		// again (rate limited).
 		return nil, nil, fmt.Errorf("failed to find resource referenced by paramKind: '%v'", *paramSource)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_restmapper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_restmapper_test.go
@@ -33,9 +33,9 @@ import (
 
 // fakeResettableRESTMapper simulates a DeferredDiscoveryRESTMapper that was
 // populated with a stale discovery result: RESTMapping fails until Reset() is
-// called, at which point it succeeds. This mirrors the Mode B race condition
-// where the apiserver restarts before the CRD controller finishes
-// re-registering the API group.
+// called, at which point it succeeds. This mirrors the race condition where 
+// the apiserver restarts before the CRD controller finishes re-registering 
+// the API group.
 type fakeResettableRESTMapper struct {
 	mu       sync.Mutex
 	resetted bool
@@ -150,8 +150,7 @@ func newMinimalPolicySource(mapper meta.RESTMapper) *policySource[runtime.Object
 // RESTMapping fails with a fresh-but-stale discovery cache, ensureParamsForPolicyLocked
 // calls Reset() and retries, succeeding on the second attempt.
 //
-// This is the core Fix 3 behavior: the Mode B race window shrinks from ~30s
-// (scheduled ticker) to ~1-5s (time for CRD re-registration).
+// The race window shrinks from ~30s (scheduled ticker) to ~1-5s (time for CRD re-registration).
 func TestEnsureParamsForPolicyLocked_RESTMapperResetOnMiss(t *testing.T) {
 	mapper := &fakeResettableRESTMapper{}
 	s := newMinimalPolicySource(mapper)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_restmapper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_restmapper_test.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// fakeResettableRESTMapper simulates a DeferredDiscoveryRESTMapper that was
+// populated with a stale discovery result: RESTMapping fails until Reset() is
+// called, at which point it succeeds. This mirrors the Mode B race condition
+// where the apiserver restarts before the CRD controller finishes
+// re-registering the API group.
+type fakeResettableRESTMapper struct {
+	mu       sync.Mutex
+	resetted bool
+	calls    int
+}
+
+var _ meta.RESTMapper = (*fakeResettableRESTMapper)(nil)
+
+func (f *fakeResettableRESTMapper) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.resetted = true
+}
+
+func (f *fakeResettableRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if !f.resetted {
+		return nil, &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{
+			Group:   gk.Group,
+			Version: versions[0],
+		}}
+	}
+	return &meta.RESTMapping{
+		Resource:         schema.GroupVersionResource{Group: gk.Group, Version: versions[0], Resource: "parameters"},
+		GroupVersionKind: schema.GroupVersionKind{Group: gk.Group, Version: versions[0], Kind: gk.Kind},
+		Scope:            meta.RESTScopeRoot,
+	}, nil
+}
+
+func (f *fakeResettableRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+func (f *fakeResettableRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, nil
+}
+func (f *fakeResettableRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, nil
+}
+func (f *fakeResettableRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, nil
+}
+func (f *fakeResettableRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return nil, nil
+}
+func (f *fakeResettableRESTMapper) ResourceSingularizer(resource string) (string, error) {
+	return resource, nil
+}
+
+// fakeAlwaysFailRESTMapper always returns an error from RESTMapping, even
+// after Reset(), simulating a CRD that genuinely does not exist.
+type fakeAlwaysFailRESTMapper struct {
+	mu      sync.Mutex
+	calls   int
+	failErr error
+}
+
+var _ meta.RESTMapper = (*fakeAlwaysFailRESTMapper)(nil)
+
+func (f *fakeAlwaysFailRESTMapper) Reset() {}
+func (f *fakeAlwaysFailRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return nil, f.failErr
+}
+func (f *fakeAlwaysFailRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, nil
+}
+func (f *fakeAlwaysFailRESTMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, nil
+}
+func (f *fakeAlwaysFailRESTMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, nil
+}
+func (f *fakeAlwaysFailRESTMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, nil
+}
+func (f *fakeAlwaysFailRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return nil, nil
+}
+func (f *fakeAlwaysFailRESTMapper) ResourceSingularizer(resource string) (string, error) {
+	return resource, nil
+}
+
+// newMinimalPolicySource creates a policySource with the fields needed for
+// ensureParamsForPolicyLocked to function, using fake clients for the
+// informer fallback path.
+//
+// The context is pre-cancelled so that any informer goroutines spawned by
+// ensureParamsForPolicyLocked exit immediately without attempting a LIST
+// against the fake dynamic client.
+func newMinimalPolicySource(mapper meta.RESTMapper) *policySource[runtime.Object, runtime.Object, Evaluator] {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel: informer goroutines stop before attempting LIST
+
+	fakeClient := fake.NewSimpleClientset()
+	fakeInformerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	fakeDynamicClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+	return &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:                  ctx,
+		restMapper:           mapper,
+		paramsCRDControllers: map[schema.GroupVersionKind]*paramInfo{},
+		informerFactory:      fakeInformerFactory,
+		dynamicClient:        fakeDynamicClient,
+	}
+}
+
+// TestEnsureParamsForPolicyLocked_RESTMapperResetOnMiss verifies that when
+// RESTMapping fails with a fresh-but-stale discovery cache, ensureParamsForPolicyLocked
+// calls Reset() and retries, succeeding on the second attempt.
+//
+// This is the core Fix 3 behavior: the Mode B race window shrinks from ~30s
+// (scheduled ticker) to ~1-5s (time for CRD re-registration).
+func TestEnsureParamsForPolicyLocked_RESTMapperResetOnMiss(t *testing.T) {
+	mapper := &fakeResettableRESTMapper{}
+	s := newMinimalPolicySource(mapper)
+
+	paramGVK := &schema.GroupVersionKind{
+		Group:   "vap.datadoghq.com",
+		Version: "v1",
+		Kind:    "Parameter",
+	}
+
+	s.lock.Lock()
+	informer, scope, err := s.ensureParamsForPolicyLocked(paramGVK)
+	s.lock.Unlock()
+
+	if err != nil {
+		t.Fatalf("expected Reset()+retry to succeed, got error: %v", err)
+	}
+	if informer == nil {
+		t.Error("expected non-nil informer after successful resolution")
+	}
+	if scope == nil {
+		t.Error("expected non-nil scope after successful resolution")
+	}
+	if mapper.calls != 2 {
+		t.Errorf("expected 2 RESTMapping calls (1 before Reset, 1 after), got %d", mapper.calls)
+	}
+	if !mapper.resetted {
+		t.Error("expected Reset() to have been called after the first RESTMapping failure")
+	}
+}
+
+// TestEnsureParamsForPolicyLocked_PermanentMissReturnsError verifies that
+// when Reset() is called but RESTMapping still fails (CRD genuinely absent),
+// the "failed to find resource referenced by paramKind" error is returned.
+func TestEnsureParamsForPolicyLocked_PermanentMissReturnsError(t *testing.T) {
+	mapper := &fakeAlwaysFailRESTMapper{
+		failErr: errors.New("no matches for kind Parameter in group vap.datadoghq.com"),
+	}
+	s := newMinimalPolicySource(mapper)
+
+	paramGVK := &schema.GroupVersionKind{
+		Group:   "vap.datadoghq.com",
+		Version: "v1",
+		Kind:    "Parameter",
+	}
+
+	s.lock.Lock()
+	_, _, err := s.ensureParamsForPolicyLocked(paramGVK)
+	s.lock.Unlock()
+
+	if err == nil {
+		t.Fatal("expected error for permanently absent CRD, got nil")
+	}
+
+	const wantErrSubstr = "failed to find resource referenced by paramKind"
+	if !strings.Contains(err.Error(), wantErrSubstr) {
+		t.Errorf("expected error to contain %q, got: %v", wantErrSubstr, err)
+	}
+
+	// Reset() should have been called once, then the second call also failed.
+	if mapper.calls != 2 {
+		t.Errorf("expected 2 RESTMapping calls (initial + post-Reset retry), got %d", mapper.calls)
+	}
+}
+
+// TestEnsureParamsForPolicyLocked_NonResettableMapperPropagatesError verifies
+// that when the RESTMapper does not implement Reset(), the original error is
+// propagated without panicking. The type-assertion guard must be a no-op.
+func TestEnsureParamsForPolicyLocked_NonResettableMapperPropagatesError(t *testing.T) {
+	// meta.DefaultRESTMapper does not implement Reset().
+	mapper := meta.NewDefaultRESTMapper(nil)
+	s := newMinimalPolicySource(mapper)
+
+	paramGVK := &schema.GroupVersionKind{
+		Group:   "vap.datadoghq.com",
+		Version: "v1",
+		Kind:    "Parameter",
+	}
+
+	s.lock.Lock()
+	_, _, err := s.ensureParamsForPolicyLocked(paramGVK)
+	s.lock.Unlock()
+
+	if err == nil {
+		t.Fatal("expected error when GVK is not registered, got nil")
+	}
+
+	const wantErrSubstr = "failed to find resource referenced by paramKind"
+	if !strings.Contains(err.Error(), wantErrSubstr) {
+		t.Errorf("expected error to contain %q, got: %v", wantErrSubstr, err)
+	}
+}


### PR DESCRIPTION
## Summary

- When `ensureParamsForPolicyLocked` cannot resolve a `paramKind` GVK via `RESTMapping`, it now calls `Reset()` on the mapper (if the concrete type supports it) and retries once before returning an error.
- This shrinks the race window from ~30s (scheduled ticker) to ~1–5s (time for CRD re-registration after apiserver restart).
- If the CRD genuinely does not exist, the second call also fails and the existing rate-limited retry path applies — no behavioral change.

## Background

`DeferredDiscoveryRESTMapper.RESTMapping()` has a built-in retry:

```go
if err != nil && !d.cl.Fresh() {
    d.Reset()
    m, err = d.RESTMapping(gk, versions...)
}
```

The problem is specifically a **fresh-but-wrong** cache: if the apiserver restarted before the CRD controller finished re-registering the API group, the cache gets populated without the CRD, is then marked "fresh", and the built-in retry does not fire. The policy reconciler re-queues on error (~1s), but keeps hitting the stale cache for ~30s until the scheduled `Reset()` ticker fires.

## Implementation

```go
type resettable interface{ Reset() }
if r, ok := s.restMapper.(resettable); ok {
    r.Reset()
    mapping, err = s.restMapper.RESTMapping(...)
}
```

The inline `resettable` interface keeps the code decoupled from the concrete `DeferredDiscoveryRESTMapper` type and safely no-ops on test doubles that don't implement `Reset()`.

## Release intent

This branch is based on `v1.34.5-dd.1` (`c13ab9367cf`). If this PR passes review, it is intended to be released as `v1.34.5-dd.2`.

## Tests

Three new unit tests in `policy_source_restmapper_test.go`:

1. `TestEnsureParamsForPolicyLocked_RESTMapperResetOnMiss` — happy path: stale cache, `Reset()` called, retry succeeds, `mapper.calls == 2`
2. `TestEnsureParamsForPolicyLocked_PermanentMissReturnsError` — CRD genuinely absent: both calls fail, "failed to find resource referenced by paramKind" returned, `mapper.calls == 2`
3. `TestEnsureParamsForPolicyLocked_NonResettableMapperPropagatesError` — `meta.DefaultRESTMapper` (no `Reset()`): no panic, error propagated

```
go test k8s.io/apiserver/pkg/admission/plugin/policy/generic/... -v -run TestEnsureParams
```

## References

- Issue: kubernetes/kubernetes#124237
- Related: kubernetes/kubernetes#123003 (merged v1.30, backported v1.29)
- Related DD PR: k8s-platform-resources#21136 (param object level — same stale-cache pattern)

🤖 Generated with [Claude Code](https://claude.ai/code)