### PR TITLE
PodStatusBatchUpdates

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -737,6 +737,12 @@ const (
 	//
 	// Enables reporting of PodReadyToStartContainersCondition condition in pod status after pod
 	// sandbox creation and network configuration completes successfully
+	// owner: @bob
+	//
+	// Enables batching of pod status updates within a configurable time window
+	// to reduce API server and etcd load.
+	PodStatusBatchUpdates featuregate.Feature = "PodStatusBatchUpdates"
+
 	PodReadyToStartContainersCondition featuregate.Feature = "PodReadyToStartContainersCondition"
 
 	// owner: @Huang-Wei
@@ -1634,6 +1640,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.34"), Default: true, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // GA in 1.35, remove in 1.38
+	},
+
+	PodStatusBatchUpdates: {
+		{Version: version.MustParse("1.35"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	PodReadyToStartContainersCondition: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -737,13 +737,13 @@ const (
 	//
 	// Enables reporting of PodReadyToStartContainersCondition condition in pod status after pod
 	// sandbox creation and network configuration completes successfully
+	PodReadyToStartContainersCondition featuregate.Feature = "PodReadyToStartContainersCondition"
+
 	// owner: @bob
 	//
 	// Enables batching of pod status updates within a configurable time window
 	// to reduce API server and etcd load.
 	PodStatusBatchUpdates featuregate.Feature = "PodStatusBatchUpdates"
-
-	PodReadyToStartContainersCondition featuregate.Feature = "PodReadyToStartContainersCondition"
 
 	// owner: @Huang-Wei
 	// kep: https://kep.k8s.io/3521

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -54,6 +54,7 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
 	_ "k8s.io/kubernetes/pkg/volume/hostpath"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 )
 
@@ -2406,7 +2407,7 @@ func TestRecordPodDeferredAcceptedResizes(t *testing.T) {
 
 func makeAllocationManager(t *testing.T, runtime *containertest.FakeRuntime, allocatedPods []*v1.Pod, nodeConfig *cm.NodeConfig) Manager {
 	t.Helper()
-	statusManager := status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker())
+	statusManager := status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker(), clock.RealClock{}, 0)
 	var containerManager *cm.FakeContainerManager
 	if nodeConfig == nil {
 		containerManager = cm.NewFakeContainerManager()

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -539,6 +539,13 @@ type KubeletConfiguration struct {
 	// +optional
 	CrashLoopBackOff CrashLoopBackOffConfig
 
+	// PodStatusUpdateBatchWindow is the duration to wait before flushing a pod's
+	// status update to the API server, allowing multiple container state changes
+	// to be coalesced into a single update. Zero means disabled.
+	// +featureGate=PodStatusBatchUpdates
+	// +optional
+	PodStatusUpdateBatchWindow metav1.Duration
+
 	// UserNamespaces contains User Namespace configurations.
 	// +featureGate=UserNamespacesSupport
 	// +optional

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -314,6 +314,12 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 		}
 	}
 
+	if localFeatureGate.Enabled(features.PodStatusBatchUpdates) {
+		if obj.PodStatusUpdateBatchWindow == zeroDuration {
+			obj.PodStatusUpdateBatchWindow = metav1.Duration{Duration: 1 * time.Second}
+		}
+	}
+
 	if localFeatureGate.Enabled(features.KubeletEnsureSecretPulledImages) {
 		if obj.ImagePullCredentialsVerificationPolicy == "" {
 			obj.ImagePullCredentialsVerificationPolicy = kubeletconfigv1beta1.NeverVerifyPreloadedImages

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -738,6 +738,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	if err := Convert_v1beta1_CrashLoopBackOffConfig_To_config_CrashLoopBackOffConfig(&in.CrashLoopBackOff, &out.CrashLoopBackOff, s); err != nil {
 		return err
 	}
+	out.PodStatusUpdateBatchWindow = in.PodStatusUpdateBatchWindow
 	out.ReservedMemory = *(*[]config.MemoryReservation)(unsafe.Pointer(&in.ReservedMemory))
 	if err := v1.Convert_Pointer_bool_To_bool(&in.EnableProfilingHandler, &out.EnableProfilingHandler, s); err != nil {
 		return err
@@ -968,6 +969,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	if err := Convert_config_CrashLoopBackOffConfig_To_v1beta1_CrashLoopBackOffConfig(&in.CrashLoopBackOff, &out.CrashLoopBackOff, s); err != nil {
 		return err
 	}
+	out.PodStatusUpdateBatchWindow = in.PodStatusUpdateBatchWindow
 	out.UserNamespaces = (*configv1beta1.UserNamespaces)(unsafe.Pointer(in.UserNamespaces))
 	return nil
 }

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -227,6 +227,14 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration, featur
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: FeatureGate KubeletCrashLoopBackOffMax not enabled, CrashLoopBackOff.MaxContainerRestartPeriod must not be set"))
 	}
 
+	if localFeatureGate.Enabled(features.PodStatusBatchUpdates) {
+		if kc.PodStatusUpdateBatchWindow.Duration < 250*time.Millisecond || kc.PodStatusUpdateBatchWindow.Duration > 5*time.Second {
+			allErrors = append(allErrors, fmt.Errorf("invalid configuration: PodStatusUpdateBatchWindow must be between 250ms and 5s when PodStatusBatchUpdates is enabled, got %v", kc.PodStatusUpdateBatchWindow.Duration))
+		}
+	} else if kc.PodStatusUpdateBatchWindow.Duration != 0 {
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: PodStatusUpdateBatchWindow must not be set when PodStatusBatchUpdates feature gate is disabled"))
+	}
+
 	// Check for mutually exclusive keys before the main validation loop
 	reservedKeys := map[string]bool{
 		kubetypes.SystemReservedEnforcementKey:             false,

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -777,3 +777,97 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateKubeletConfiguration_PodStatusBatchWindow(t *testing.T) {
+	featureGate := utilfeature.DefaultFeatureGate.DeepCopy()
+	logsapi.AddFeatureGates(featureGate)
+
+	cases := []struct {
+		name      string
+		configure func(config *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration
+		errMsg    string
+	}{
+		{
+			name: "gate enabled, valid 1s",
+			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+				conf.FeatureGates = map[string]bool{"PodStatusBatchUpdates": true, "CustomCPUCFSQuotaPeriod": true}
+				conf.PodStatusUpdateBatchWindow = metav1.Duration{Duration: 1 * time.Second}
+				return conf
+			},
+		},
+		{
+			name: "gate enabled, below minimum 100ms",
+			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+				conf.FeatureGates = map[string]bool{"PodStatusBatchUpdates": true, "CustomCPUCFSQuotaPeriod": true}
+				conf.PodStatusUpdateBatchWindow = metav1.Duration{Duration: 100 * time.Millisecond}
+				return conf
+			},
+			errMsg: "invalid configuration: PodStatusUpdateBatchWindow must be between 250ms and 5s when PodStatusBatchUpdates is enabled",
+		},
+		{
+			name: "gate enabled, above maximum 10s",
+			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+				conf.FeatureGates = map[string]bool{"PodStatusBatchUpdates": true, "CustomCPUCFSQuotaPeriod": true}
+				conf.PodStatusUpdateBatchWindow = metav1.Duration{Duration: 10 * time.Second}
+				return conf
+			},
+			errMsg: "invalid configuration: PodStatusUpdateBatchWindow must be between 250ms and 5s when PodStatusBatchUpdates is enabled",
+		},
+		{
+			name: "gate enabled, at minimum boundary 250ms",
+			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+				conf.FeatureGates = map[string]bool{"PodStatusBatchUpdates": true, "CustomCPUCFSQuotaPeriod": true}
+				conf.PodStatusUpdateBatchWindow = metav1.Duration{Duration: 250 * time.Millisecond}
+				return conf
+			},
+		},
+		{
+			name: "gate enabled, at maximum boundary 5s",
+			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+				conf.FeatureGates = map[string]bool{"PodStatusBatchUpdates": true, "CustomCPUCFSQuotaPeriod": true}
+				conf.PodStatusUpdateBatchWindow = metav1.Duration{Duration: 5 * time.Second}
+				return conf
+			},
+		},
+		{
+			name: "gate disabled, non-zero window",
+			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+				conf.FeatureGates = map[string]bool{"PodStatusBatchUpdates": false, "CustomCPUCFSQuotaPeriod": true}
+				conf.PodStatusUpdateBatchWindow = metav1.Duration{Duration: 1 * time.Second}
+				return conf
+			},
+			errMsg: "invalid configuration: PodStatusUpdateBatchWindow must not be set when PodStatusBatchUpdates feature gate is disabled",
+		},
+		{
+			name: "gate disabled, zero window",
+			configure: func(conf *kubeletconfig.KubeletConfiguration) *kubeletconfig.KubeletConfiguration {
+				conf.FeatureGates = map[string]bool{"PodStatusBatchUpdates": false, "CustomCPUCFSQuotaPeriod": true}
+				conf.PodStatusUpdateBatchWindow = metav1.Duration{Duration: 0}
+				return conf
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := validation.ValidateKubeletConfiguration(tc.configure(successConfig.DeepCopy()), featureGate)
+
+			if len(tc.errMsg) == 0 {
+				if errs != nil {
+					t.Errorf("unexpected error: %s", errs)
+				}
+
+				return
+			}
+
+			if errs == nil {
+				t.Errorf("expected error: %s", tc.errMsg)
+				return
+			}
+
+			if got := errs.Error(); !strings.Contains(got, tc.errMsg) {
+				t.Errorf("unexpected error: %s expected to contain %s", got, tc.errMsg)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -688,7 +688,11 @@ func NewMainKubelet(ctx context.Context,
 	klet.mirrorPodClient = kubepod.NewBasicMirrorClient(klet.kubeClient, string(nodeName), nodeLister)
 	klet.podManager = kubepod.NewBasicPodManager()
 
-	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet, kubeDeps.PodStartupLatencyTracker)
+	var batchWindow time.Duration
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodStatusBatchUpdates) {
+		batchWindow = kubeCfg.PodStatusUpdateBatchWindow.Duration
+	}
+	klet.statusManager = status.NewManager(klet.kubeClient, klet.podManager, klet, kubeDeps.PodStartupLatencyTracker, clock.RealClock{}, batchWindow)
 	klet.allocationManager = allocation.NewManager(
 		klet.getRootDir(),
 		klet.containerManager.GetNodeConfig(),

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -303,7 +303,7 @@ func newTestKubeletWithImageList(
 	kubelet.mirrorPodClient = fakeMirrorClient
 	kubelet.podManager = kubepod.NewBasicPodManager()
 	podStartupLatencyTracker := kubeletutil.NewPodStartupLatencyTracker()
-	kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker)
+	kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, clock.RealClock{}, 0)
 	kubelet.nodeStartupLatencyTracker = kubeletutil.NewNodeStartupLatencyTracker()
 	kubelet.podCertificateManager = &podcertificate.NoOpManager{}
 

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -177,6 +177,12 @@ const (
 	PodInProgressResizesKey          = "pod_in_progress_resizes"
 	PodDeferredAcceptedResizesKey    = "pod_deferred_accepted_resizes_total"
 
+	// Metric keys for pod status batching.
+	PodStatusBatchCoalescedKey  = "pod_status_batch_coalesced_total"
+	PodStatusBatchDelayKey      = "pod_status_batch_delay_seconds"
+	PodStatusBatchPendingKey    = "pod_status_batch_pending_pods"
+	PodStatusBatchBypassKey     = "pod_status_batch_bypass_total"
+
 	// Metric key for podcertificate states.
 	PodCertificateStatesKey = "podcertificate_states"
 )
@@ -1193,6 +1199,44 @@ var (
 		},
 		[]string{"retry_trigger"},
 	)
+
+	PodStatusBatchCoalesced = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodStatusBatchCoalescedKey,
+			Help:           "Number of intermediate pod status updates absorbed by batching.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	PodStatusBatchDelay = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodStatusBatchDelayKey,
+			Help:           "Actual delay in seconds from the first pending status change to the batch flush.",
+			Buckets:        []float64{0.1, 0.25, 0.5, 1, 2, 3, 5},
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	PodStatusBatchPending = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodStatusBatchPendingKey,
+			Help:           "Number of pods with unflushed batched status updates.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+
+	PodStatusBatchBypass = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PodStatusBatchBypassKey,
+			Help:           "Number of pod status updates that bypassed batching.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"reason"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -1301,6 +1345,13 @@ func Register() {
 			legacyregistry.MustRegister(ImageVolumeRequestedTotal)
 			legacyregistry.MustRegister(ImageVolumeMountedSucceedTotal)
 			legacyregistry.MustRegister(ImageVolumeMountedErrorsTotal)
+		}
+
+		if utilfeature.DefaultFeatureGate.Enabled(features.PodStatusBatchUpdates) {
+			legacyregistry.MustRegister(PodStatusBatchCoalesced)
+			legacyregistry.MustRegister(PodStatusBatchDelay)
+			legacyregistry.MustRegister(PodStatusBatchPending)
+			legacyregistry.MustRegister(PodStatusBatchBypass)
 		}
 
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -31,6 +31,7 @@ import (
 	statustest "k8s.io/kubernetes/pkg/kubelet/status/testing"
 	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/probe"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/exec"
 )
 
@@ -157,7 +158,7 @@ func newTestManager() *manager {
 	// Add test pod to pod manager, so that status manager can get the pod from pod manager if needed.
 	podManager.AddPod(getTestPod())
 	m := NewManager(
-		status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker),
+		status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, clock.RealClock{}, 0),
 		results.NewManager(),
 		results.NewManager(),
 		results.NewManager(),

--- a/pkg/kubelet/prober/scale_test.go
+++ b/pkg/kubelet/prober/scale_test.go
@@ -37,6 +37,7 @@ import (
 	statustest "k8s.io/kubernetes/pkg/kubelet/status/testing"
 	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
 )
 
@@ -84,7 +85,7 @@ func TestTCPPortExhaustion(t *testing.T) {
 			podManager := kubepod.NewBasicPodManager()
 			podStartupLatencyTracker := kubeletutil.NewPodStartupLatencyTracker()
 			m := NewManager(
-				status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker),
+				status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, clock.RealClock{}, 0),
 				results.NewManager(),
 				results.NewManager(),
 				results.NewManager(),

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -36,6 +36,7 @@ import (
 	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/probe"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/clock"
 )
 
 func init() {
@@ -174,7 +175,7 @@ func TestDoProbe(t *testing.T) {
 				t.Errorf("[%s-%d] Expected result: %v but got %v", probeType, i, test.expectedResult, result)
 			}
 
-			m.statusManager = status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker())
+			m.statusManager = status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker(), clock.RealClock{}, 0)
 			resultsManager(m, probeType).Remove(testContainerID)
 		}
 	}

--- a/pkg/kubelet/status/bypass_test.go
+++ b/pkg/kubelet/status/bypass_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,100 +24,102 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func podStatusWithReady(status v1.ConditionStatus) v1.PodStatus {
-	return v1.PodStatus{
-		Conditions: []v1.PodCondition{
-			{Type: v1.PodReady, Status: status},
-		},
-	}
+func podStatusWithConditions(conditions ...v1.PodCondition) v1.PodStatus {
+	return v1.PodStatus{Conditions: conditions}
 }
 
 func podStatusWithPhase(phase v1.PodPhase) v1.PodStatus {
 	return v1.PodStatus{Phase: phase}
 }
 
-func TestShouldBypass_ForceUpdate(t *testing.T) {
-	old := v1.PodStatus{}
-	new := v1.PodStatus{}
-	assert.True(t, shouldBypass(true, &old, &new), "forceUpdate=true should always bypass")
-}
-
-func TestShouldBypass_NoChange(t *testing.T) {
-	old := podStatusWithReady(v1.ConditionFalse)
-	new := podStatusWithReady(v1.ConditionFalse)
-	assert.False(t, shouldBypass(false, &old, &new), "no change should not bypass")
-}
-
-func TestShouldBypass_PodBecameReady(t *testing.T) {
-	old := podStatusWithReady(v1.ConditionFalse)
-	new := podStatusWithReady(v1.ConditionTrue)
-	assert.True(t, shouldBypass(false, &old, &new), "PodReady False→True should bypass")
-}
-
-func TestShouldBypass_PodBecameUnready(t *testing.T) {
-	old := podStatusWithReady(v1.ConditionTrue)
-	new := podStatusWithReady(v1.ConditionFalse)
-	assert.True(t, shouldBypass(false, &old, &new), "PodReady True→False should bypass")
-}
-
-func TestShouldBypass_PodReadyFromUnknown(t *testing.T) {
-	old := podStatusWithReady(v1.ConditionUnknown)
-	new := podStatusWithReady(v1.ConditionTrue)
-	assert.True(t, shouldBypass(false, &old, &new), "PodReady Unknown→True should bypass")
-}
-
-func TestShouldBypass_PodReadyFirstReport(t *testing.T) {
-	old := v1.PodStatus{}
-	new := podStatusWithReady(v1.ConditionTrue)
-	assert.True(t, shouldBypass(false, &old, &new), "first report with PodReady=True should bypass")
-}
-
-func TestShouldBypass_PodReadyFirstReportNotReady(t *testing.T) {
-	old := v1.PodStatus{}
-	new := podStatusWithReady(v1.ConditionFalse)
-	// First report with PodReady=False — old has no PodReady condition (implicitly not-ready).
-	// No transition occurred, so no bypass.
-	assert.False(t, shouldBypass(false, &old, &new), "first report with PodReady=False should not bypass (no transition)")
-}
-
-func TestShouldBypass_PodReadyUnchangedTrue(t *testing.T) {
-	old := podStatusWithReady(v1.ConditionTrue)
-	new := podStatusWithReady(v1.ConditionTrue)
-	assert.False(t, shouldBypass(false, &old, &new), "PodReady unchanged (True→True) should not bypass")
-}
-
-func TestShouldBypass_TerminalPhaseFailed(t *testing.T) {
-	old := podStatusWithPhase(v1.PodRunning)
-	new := podStatusWithPhase(v1.PodFailed)
-	assert.True(t, shouldBypass(false, &old, &new), "phase transition to Failed should bypass")
-}
-
-func TestShouldBypass_TerminalPhaseSucceeded(t *testing.T) {
-	old := podStatusWithPhase(v1.PodRunning)
-	new := podStatusWithPhase(v1.PodSucceeded)
-	assert.True(t, shouldBypass(false, &old, &new), "phase transition to Succeeded should bypass")
-}
-
-func TestShouldBypass_TerminalPhaseAlreadyTerminal(t *testing.T) {
-	old := podStatusWithPhase(v1.PodFailed)
-	new := podStatusWithPhase(v1.PodFailed)
-	assert.False(t, shouldBypass(false, &old, &new), "unchanged terminal phase should not bypass")
-}
-
-func TestShouldBypass_NonTerminalPhaseChange(t *testing.T) {
-	old := podStatusWithPhase(v1.PodPending)
-	new := podStatusWithPhase(v1.PodRunning)
-	assert.False(t, shouldBypass(false, &old, &new), "Pending→Running should not bypass")
-}
-
-func TestShouldBypass_CombinedReadyAndTerminal(t *testing.T) {
-	old := v1.PodStatus{
-		Phase:      v1.PodRunning,
-		Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+func TestShouldBypass(t *testing.T) {
+	ready := func(s v1.ConditionStatus) v1.PodCondition {
+		return v1.PodCondition{Type: v1.PodReady, Status: s}
 	}
-	new := v1.PodStatus{
-		Phase:      v1.PodFailed,
-		Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}},
+	containersReady := func(s v1.ConditionStatus) v1.PodCondition {
+		return v1.PodCondition{Type: v1.ContainersReady, Status: s}
 	}
-	assert.True(t, shouldBypass(false, &old, &new), "both readiness change and terminal phase should bypass")
+
+	tests := []struct {
+		name        string
+		forceUpdate bool
+		old, new    v1.PodStatus
+		want        bool
+	}{
+		{name: "force update always bypasses", forceUpdate: true, want: true},
+
+		{name: "no change", old: podStatusWithConditions(ready(v1.ConditionFalse)), new: podStatusWithConditions(ready(v1.ConditionFalse)), want: false},
+
+		{name: "PodReady False→True", old: podStatusWithConditions(ready(v1.ConditionFalse)), new: podStatusWithConditions(ready(v1.ConditionTrue)), want: true},
+		{name: "PodReady True→False", old: podStatusWithConditions(ready(v1.ConditionTrue)), new: podStatusWithConditions(ready(v1.ConditionFalse)), want: true},
+		{name: "PodReady Unknown→True", old: podStatusWithConditions(ready(v1.ConditionUnknown)), new: podStatusWithConditions(ready(v1.ConditionTrue)), want: true},
+		{name: "PodReady first report True", old: v1.PodStatus{}, new: podStatusWithConditions(ready(v1.ConditionTrue)), want: true},
+		{name: "PodReady first report False is no transition", old: v1.PodStatus{}, new: podStatusWithConditions(ready(v1.ConditionFalse)), want: false},
+		{name: "PodReady unchanged True", old: podStatusWithConditions(ready(v1.ConditionTrue)), new: podStatusWithConditions(ready(v1.ConditionTrue)), want: false},
+
+		{name: "ContainersReady False→True", old: podStatusWithConditions(containersReady(v1.ConditionFalse)), new: podStatusWithConditions(containersReady(v1.ConditionTrue)), want: true},
+		{name: "ContainersReady True→False", old: podStatusWithConditions(containersReady(v1.ConditionTrue)), new: podStatusWithConditions(containersReady(v1.ConditionFalse)), want: true},
+		{name: "ContainersReady unchanged", old: podStatusWithConditions(containersReady(v1.ConditionTrue)), new: podStatusWithConditions(containersReady(v1.ConditionTrue)), want: false},
+
+		// Missing conditions default to ConditionFalse: removal of a True condition
+		// is observed as True→False and must bypass.
+		{name: "PodReady removed from conditions", old: podStatusWithConditions(ready(v1.ConditionTrue)), new: v1.PodStatus{}, want: true},
+		{name: "ContainersReady removed from conditions", old: podStatusWithConditions(containersReady(v1.ConditionTrue)), new: v1.PodStatus{}, want: true},
+
+		{name: "phase Running→Failed", old: podStatusWithPhase(v1.PodRunning), new: podStatusWithPhase(v1.PodFailed), want: true},
+		{name: "phase Running→Succeeded", old: podStatusWithPhase(v1.PodRunning), new: podStatusWithPhase(v1.PodSucceeded), want: true},
+		{name: "phase already terminal", old: podStatusWithPhase(v1.PodFailed), new: podStatusWithPhase(v1.PodFailed), want: false},
+		{name: "phase Pending→Running (non-terminal)", old: podStatusWithPhase(v1.PodPending), new: podStatusWithPhase(v1.PodRunning), want: false},
+		// Rule is "new phase is terminal", not "transitioned into terminal":
+		// backward transitions do not bypass; terminal→terminal changes do.
+		{name: "phase Failed→Running (backward)", old: podStatusWithPhase(v1.PodFailed), new: podStatusWithPhase(v1.PodRunning), want: false},
+		{name: "phase Failed→Succeeded (terminal→terminal)", old: podStatusWithPhase(v1.PodFailed), new: podStatusWithPhase(v1.PodSucceeded), want: true},
+
+		{
+			name: "readiness change and terminal phase combined",
+			old:  v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{ready(v1.ConditionTrue)}},
+			new:  v1.PodStatus{Phase: v1.PodFailed, Conditions: []v1.PodCondition{ready(v1.ConditionFalse)}},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, shouldBypass(tt.forceUpdate, &tt.old, &tt.new))
+		})
+	}
+}
+
+func TestBypassReason(t *testing.T) {
+	tests := []struct {
+		name        string
+		forceUpdate bool
+		old, new    v1.PodStatus
+		want        string
+	}{
+		{"force", true, v1.PodStatus{}, v1.PodStatus{}, "force"},
+		{"ready", false,
+			podStatusWithConditions(v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionFalse}),
+			podStatusWithConditions(v1.PodCondition{Type: v1.PodReady, Status: v1.ConditionTrue}),
+			"ready"},
+		{"containers_ready", false,
+			podStatusWithConditions(v1.PodCondition{Type: v1.ContainersReady, Status: v1.ConditionFalse}),
+			podStatusWithConditions(v1.PodCondition{Type: v1.ContainersReady, Status: v1.ConditionTrue}),
+			"ready"},
+		{"terminal", false,
+			podStatusWithPhase(v1.PodRunning),
+			podStatusWithPhase(v1.PodFailed),
+			"terminal"},
+		// Ordering contract: when both readiness and phase-terminal fire,
+		// reason is "ready" (switch in bypassReason evaluates ready first).
+		{"ready wins over terminal", false,
+			v1.PodStatus{Phase: v1.PodRunning, Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}},
+			v1.PodStatus{Phase: v1.PodFailed, Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}},
+			"ready"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, bypassReason(tt.forceUpdate, &tt.old, &tt.new))
+		})
+	}
 }

--- a/pkg/kubelet/status/bypass_test.go
+++ b/pkg/kubelet/status/bypass_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+func podStatusWithReady(status v1.ConditionStatus) v1.PodStatus {
+	return v1.PodStatus{
+		Conditions: []v1.PodCondition{
+			{Type: v1.PodReady, Status: status},
+		},
+	}
+}
+
+func podStatusWithPhase(phase v1.PodPhase) v1.PodStatus {
+	return v1.PodStatus{Phase: phase}
+}
+
+func TestShouldBypass_ForceUpdate(t *testing.T) {
+	old := v1.PodStatus{}
+	new := v1.PodStatus{}
+	assert.True(t, shouldBypass(true, &old, &new), "forceUpdate=true should always bypass")
+}
+
+func TestShouldBypass_NoChange(t *testing.T) {
+	old := podStatusWithReady(v1.ConditionFalse)
+	new := podStatusWithReady(v1.ConditionFalse)
+	assert.False(t, shouldBypass(false, &old, &new), "no change should not bypass")
+}
+
+func TestShouldBypass_PodBecameReady(t *testing.T) {
+	old := podStatusWithReady(v1.ConditionFalse)
+	new := podStatusWithReady(v1.ConditionTrue)
+	assert.True(t, shouldBypass(false, &old, &new), "PodReady False→True should bypass")
+}
+
+func TestShouldBypass_PodBecameUnready(t *testing.T) {
+	old := podStatusWithReady(v1.ConditionTrue)
+	new := podStatusWithReady(v1.ConditionFalse)
+	assert.True(t, shouldBypass(false, &old, &new), "PodReady True→False should bypass")
+}
+
+func TestShouldBypass_PodReadyFromUnknown(t *testing.T) {
+	old := podStatusWithReady(v1.ConditionUnknown)
+	new := podStatusWithReady(v1.ConditionTrue)
+	assert.True(t, shouldBypass(false, &old, &new), "PodReady Unknown→True should bypass")
+}
+
+func TestShouldBypass_PodReadyFirstReport(t *testing.T) {
+	old := v1.PodStatus{}
+	new := podStatusWithReady(v1.ConditionTrue)
+	assert.True(t, shouldBypass(false, &old, &new), "first report with PodReady=True should bypass")
+}
+
+func TestShouldBypass_PodReadyFirstReportNotReady(t *testing.T) {
+	old := v1.PodStatus{}
+	new := podStatusWithReady(v1.ConditionFalse)
+	// First report with PodReady=False — old has no PodReady condition (implicitly not-ready).
+	// No transition occurred, so no bypass.
+	assert.False(t, shouldBypass(false, &old, &new), "first report with PodReady=False should not bypass (no transition)")
+}
+
+func TestShouldBypass_PodReadyUnchangedTrue(t *testing.T) {
+	old := podStatusWithReady(v1.ConditionTrue)
+	new := podStatusWithReady(v1.ConditionTrue)
+	assert.False(t, shouldBypass(false, &old, &new), "PodReady unchanged (True→True) should not bypass")
+}
+
+func TestShouldBypass_TerminalPhaseFailed(t *testing.T) {
+	old := podStatusWithPhase(v1.PodRunning)
+	new := podStatusWithPhase(v1.PodFailed)
+	assert.True(t, shouldBypass(false, &old, &new), "phase transition to Failed should bypass")
+}
+
+func TestShouldBypass_TerminalPhaseSucceeded(t *testing.T) {
+	old := podStatusWithPhase(v1.PodRunning)
+	new := podStatusWithPhase(v1.PodSucceeded)
+	assert.True(t, shouldBypass(false, &old, &new), "phase transition to Succeeded should bypass")
+}
+
+func TestShouldBypass_TerminalPhaseAlreadyTerminal(t *testing.T) {
+	old := podStatusWithPhase(v1.PodFailed)
+	new := podStatusWithPhase(v1.PodFailed)
+	assert.False(t, shouldBypass(false, &old, &new), "unchanged terminal phase should not bypass")
+}
+
+func TestShouldBypass_NonTerminalPhaseChange(t *testing.T) {
+	old := podStatusWithPhase(v1.PodPending)
+	new := podStatusWithPhase(v1.PodRunning)
+	assert.False(t, shouldBypass(false, &old, &new), "Pending→Running should not bypass")
+}
+
+func TestShouldBypass_CombinedReadyAndTerminal(t *testing.T) {
+	old := v1.PodStatus{
+		Phase:      v1.PodRunning,
+		Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+	}
+	new := v1.PodStatus{
+		Phase:      v1.PodFailed,
+		Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}},
+	}
+	assert.True(t, shouldBypass(false, &old, &new), "both readiness change and terminal phase should bypass")
+}

--- a/pkg/kubelet/status/status_batcher.go
+++ b/pkg/kubelet/status/status_batcher.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ limitations under the License.
 package status
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -27,6 +27,9 @@ import (
 	"k8s.io/utils/clock"
 )
 
+// statusBatcher debounces pod status updates within a configurable time window.
+// Lock ordering: callers must acquire podStatusesLock before batcher.mu if both
+// are needed. The timer callback only acquires batcher.mu.
 type statusBatcher struct {
 	clock  clock.WithDelayedExecution
 	window time.Duration
@@ -46,6 +49,14 @@ func newStatusBatcher(c clock.WithDelayedExecution, window time.Duration, notify
 		firstChange: make(map[types.UID]time.Time),
 		notify:      notify,
 	}
+}
+
+// PendingCount returns the number of pods with pending batched updates.
+// Safe to call from any goroutine.
+func (b *statusBatcher) PendingCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.timers)
 }
 
 func (b *statusBatcher) Schedule(uid types.UID) {
@@ -68,14 +79,22 @@ func (b *statusBatcher) Schedule(uid types.UID) {
 		b.firstChange[uid] = now
 	}
 
-	delay := b.window + time.Duration(rand.Int63n(int64(b.window/5)))
+	delay := b.window + time.Duration(rand.Int64N(int64(b.window/5)))
 
 	if t, ok := b.timers[uid]; ok {
-		t.Reset(delay)
-		metrics.PodStatusBatchCoalesced.Inc()
-		return
+		if !t.Reset(delay) {
+			// Timer already fired — callback is in-flight or completed.
+			// Delete stale entry and create a fresh timer.
+			delete(b.timers, uid)
+		} else {
+			metrics.PodStatusBatchCoalesced.Inc()
+			return
+		}
 	}
 
+	// Capture firstChange for the delay metric. This intentionally captures
+	// the original first-change time, not the reset time, so the histogram
+	// measures total delay from the first pending change.
 	firstChange := b.firstChange[uid]
 	b.timers[uid] = b.clock.AfterFunc(delay, func() {
 		b.mu.Lock()
@@ -87,6 +106,7 @@ func (b *statusBatcher) Schedule(uid types.UID) {
 		metrics.PodStatusBatchPending.Set(float64(pending))
 		b.notify()
 	})
+	metrics.PodStatusBatchCoalesced.Inc()
 }
 
 func (b *statusBatcher) Flush(uid types.UID) {
@@ -118,7 +138,10 @@ func shouldBypass(forceUpdate bool, old, new *v1.PodStatus) bool {
 	if forceUpdate {
 		return true
 	}
-	if podReadyChanged(old, new) {
+	if conditionChanged(old, new, v1.PodReady) {
+		return true
+	}
+	if conditionChanged(old, new, v1.ContainersReady) {
 		return true
 	}
 	if phaseIsTerminal(old, new) {
@@ -127,15 +150,13 @@ func shouldBypass(forceUpdate bool, old, new *v1.PodStatus) bool {
 	return false
 }
 
-func podReadyChanged(old, new *v1.PodStatus) bool {
-	oldReady := getPodReadyStatus(old)
-	newReady := getPodReadyStatus(new)
-	return oldReady != newReady
+func conditionChanged(old, new *v1.PodStatus, condType v1.PodConditionType) bool {
+	return getConditionStatus(old, condType) != getConditionStatus(new, condType)
 }
 
-func getPodReadyStatus(status *v1.PodStatus) v1.ConditionStatus {
+func getConditionStatus(status *v1.PodStatus, condType v1.PodConditionType) v1.ConditionStatus {
 	for _, c := range status.Conditions {
-		if c.Type == v1.PodReady {
+		if c.Type == condType {
 			return c.Status
 		}
 	}
@@ -146,7 +167,7 @@ func bypassReason(forceUpdate bool, old, new *v1.PodStatus) string {
 	if forceUpdate {
 		return "force"
 	}
-	if podReadyChanged(old, new) {
+	if conditionChanged(old, new, v1.PodReady) || conditionChanged(old, new, v1.ContainersReady) {
 		return "ready"
 	}
 	if phaseIsTerminal(old, new) {

--- a/pkg/kubelet/status/status_batcher.go
+++ b/pkg/kubelet/status/status_batcher.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	"k8s.io/utils/clock"
+)
+
+type statusBatcher struct {
+	clock  clock.WithDelayedExecution
+	window time.Duration
+
+	mu          sync.Mutex
+	timers      map[types.UID]clock.Timer
+	firstChange map[types.UID]time.Time
+
+	notify func()
+}
+
+func newStatusBatcher(c clock.WithDelayedExecution, window time.Duration, notify func()) *statusBatcher {
+	return &statusBatcher{
+		clock:       c,
+		window:      window,
+		timers:      make(map[types.UID]clock.Timer),
+		firstChange: make(map[types.UID]time.Time),
+		notify:      notify,
+	}
+}
+
+func (b *statusBatcher) Schedule(uid types.UID) {
+	if b.window == 0 {
+		b.notify()
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := b.clock.Now()
+
+	if first, ok := b.firstChange[uid]; ok {
+		if now.Sub(first) >= 3*b.window {
+			b.flushLocked(uid)
+			return
+		}
+	} else {
+		b.firstChange[uid] = now
+	}
+
+	delay := b.window + time.Duration(rand.Int63n(int64(b.window/5)))
+
+	if t, ok := b.timers[uid]; ok {
+		t.Reset(delay)
+		metrics.PodStatusBatchCoalesced.Inc()
+		return
+	}
+
+	firstChange := b.firstChange[uid]
+	b.timers[uid] = b.clock.AfterFunc(delay, func() {
+		b.mu.Lock()
+		delete(b.timers, uid)
+		delete(b.firstChange, uid)
+		pending := len(b.timers)
+		b.mu.Unlock()
+		metrics.PodStatusBatchDelay.Observe(time.Since(firstChange).Seconds())
+		metrics.PodStatusBatchPending.Set(float64(pending))
+		b.notify()
+	})
+}
+
+func (b *statusBatcher) Flush(uid types.UID) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.flushLocked(uid)
+}
+
+func (b *statusBatcher) flushLocked(uid types.UID) {
+	if t, ok := b.timers[uid]; ok {
+		t.Stop()
+		delete(b.timers, uid)
+	}
+	delete(b.firstChange, uid)
+	b.notify()
+}
+
+func (b *statusBatcher) Cancel(uid types.UID) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if t, ok := b.timers[uid]; ok {
+		t.Stop()
+		delete(b.timers, uid)
+	}
+	delete(b.firstChange, uid)
+}
+
+func shouldBypass(forceUpdate bool, old, new *v1.PodStatus) bool {
+	if forceUpdate {
+		return true
+	}
+	if podReadyChanged(old, new) {
+		return true
+	}
+	if phaseIsTerminal(old, new) {
+		return true
+	}
+	return false
+}
+
+func podReadyChanged(old, new *v1.PodStatus) bool {
+	oldReady := getPodReadyStatus(old)
+	newReady := getPodReadyStatus(new)
+	return oldReady != newReady
+}
+
+func getPodReadyStatus(status *v1.PodStatus) v1.ConditionStatus {
+	for _, c := range status.Conditions {
+		if c.Type == v1.PodReady {
+			return c.Status
+		}
+	}
+	return v1.ConditionFalse
+}
+
+func bypassReason(forceUpdate bool, old, new *v1.PodStatus) string {
+	if forceUpdate {
+		return "force"
+	}
+	if podReadyChanged(old, new) {
+		return "ready"
+	}
+	if phaseIsTerminal(old, new) {
+		return "terminal"
+	}
+	return "unknown"
+}
+
+func phaseIsTerminal(old, new *v1.PodStatus) bool {
+	if old.Phase == new.Phase {
+		return false
+	}
+	return new.Phase == v1.PodFailed || new.Phase == v1.PodSucceeded
+}

--- a/pkg/kubelet/status/status_batcher_test.go
+++ b/pkg/kubelet/status/status_batcher_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Kubernetes Authors.
+Copyright 2026 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -54,7 +54,6 @@ func TestBatcherScheduleCoalesces(t *testing.T) {
 	// Window is 1s + up to 200ms jitter, so step 1.3s to be safe.
 	fakeClock.Step(1300 * time.Millisecond)
 
-	// AfterFunc callbacks run in goroutines — give them a moment.
 	require.Eventually(t, func() bool {
 		return notifyCount.Load() == 1
 	}, time.Second, 10*time.Millisecond, "exactly one notification after window expires")
@@ -106,7 +105,7 @@ func TestBatcherMaxCoalesceCap(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		return notifyCount.Load() >= 1
+		return notifyCount.Load() == 1
 	}, time.Second, 10*time.Millisecond, "notification should fire due to max coalesce cap (3x window)")
 }
 
@@ -145,10 +144,8 @@ func TestBatcherCancel(t *testing.T) {
 	b.Schedule(uid)
 	b.Cancel(uid)
 
-	fakeClock.Step(2 * time.Second)
-
-	// Give any goroutine time to fire (it shouldn't).
-	time.Sleep(50 * time.Millisecond)
+	// Timer should be removed — no waiters.
+	assert.Equal(t, 0, fakeClock.Waiters(), "cancelled timer should have no waiters")
 	assert.Equal(t, int32(0), notifyCount.Load(), "Cancel should prevent notification")
 
 	b.mu.Lock()
@@ -198,10 +195,7 @@ func TestBatcherFlushOneCancelOther(t *testing.T) {
 	b.Cancel(uid2)
 
 	assert.Equal(t, int32(1), notifyCount.Load(), "only flush should notify")
-
-	fakeClock.Step(2 * time.Second)
-	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, int32(1), notifyCount.Load(), "cancelled pod should not notify")
+	assert.Equal(t, 0, fakeClock.Waiters(), "all timers should be gone")
 }
 
 func TestBatcherDisabledWhenZeroWindow(t *testing.T) {
@@ -218,8 +212,6 @@ func TestBatcherJitterRange(t *testing.T) {
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	window := 1 * time.Second
 
-	// Run multiple rounds and verify the timer always fires
-	// within [window, window + 0.2*window] = [1s, 1.2s].
 	for i := 0; i < 10; i++ {
 		notifyCount := &atomic.Int32{}
 		b := newStatusBatcher(fakeClock, window, func() {
@@ -229,11 +221,66 @@ func TestBatcherJitterRange(t *testing.T) {
 		uid := types.UID("pod-jitter")
 		b.Schedule(uid)
 
-		// Advancing by exactly 1s should not always trigger (jitter adds 0-200ms).
-		// But advancing by 1.2s should always trigger.
-		fakeClock.Step(1200 * time.Millisecond)
+		// Window + max jitter = 1s + 200ms = 1.2s. Step 1.3s to be safe.
+		fakeClock.Step(1300 * time.Millisecond)
 		require.Eventually(t, func() bool {
 			return notifyCount.Load() == 1
 		}, time.Second, 10*time.Millisecond, "timer should fire within jitter range (iteration %d)", i)
 	}
+}
+
+func TestBatcherPendingCount(t *testing.T) {
+	b, _, _ := newTestBatcher(t, 1*time.Second)
+
+	assert.Equal(t, 0, b.PendingCount())
+
+	b.Schedule(types.UID("pod-1"))
+	assert.Equal(t, 1, b.PendingCount())
+
+	b.Schedule(types.UID("pod-2"))
+	assert.Equal(t, 2, b.PendingCount())
+
+	b.Cancel(types.UID("pod-1"))
+	assert.Equal(t, 1, b.PendingCount())
+
+	b.Flush(types.UID("pod-2"))
+	assert.Equal(t, 0, b.PendingCount())
+}
+
+func TestBatcherScheduleAfterCancel(t *testing.T) {
+	b, fakeClock, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid := types.UID("pod-1")
+
+	b.Schedule(uid)
+	b.Cancel(uid)
+	assert.Equal(t, int32(0), notifyCount.Load())
+
+	// Schedule again — should create a fresh timer.
+	b.Schedule(uid)
+	assert.Equal(t, 1, fakeClock.Waiters(), "new timer should be active")
+
+	fakeClock.Step(1300 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return notifyCount.Load() == 1
+	}, time.Second, 10*time.Millisecond, "new timer should fire")
+}
+
+func TestBatcherScheduleAfterFlush(t *testing.T) {
+	b, fakeClock, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid := types.UID("pod-1")
+
+	b.Schedule(uid)
+	b.Flush(uid)
+	assert.Equal(t, int32(1), notifyCount.Load())
+
+	// Schedule again — should create a fresh timer with fresh firstChange.
+	b.Schedule(uid)
+	assert.Equal(t, 1, fakeClock.Waiters())
+
+	fakeClock.Step(1300 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return notifyCount.Load() == 2
+	}, time.Second, 10*time.Millisecond, "second timer should fire independently")
 }

--- a/pkg/kubelet/status/status_batcher_test.go
+++ b/pkg/kubelet/status/status_batcher_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/types"
+	testingclock "k8s.io/utils/clock/testing"
+)
+
+func newTestBatcher(t *testing.T, window time.Duration) (*statusBatcher, *testingclock.FakeClock, *atomic.Int32) {
+	t.Helper()
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	notifyCount := &atomic.Int32{}
+	notify := func() {
+		notifyCount.Add(1)
+	}
+	b := newStatusBatcher(fakeClock, window, notify)
+	return b, fakeClock, notifyCount
+}
+
+func TestBatcherScheduleCoalesces(t *testing.T) {
+	b, fakeClock, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid := types.UID("pod-1")
+
+	b.Schedule(uid)
+	b.Schedule(uid)
+	b.Schedule(uid)
+
+	assert.Equal(t, int32(0), notifyCount.Load(), "no notification before window expires")
+	assert.Equal(t, 1, fakeClock.Waiters(), "exactly one timer should be active")
+
+	// Window is 1s + up to 200ms jitter, so step 1.3s to be safe.
+	fakeClock.Step(1300 * time.Millisecond)
+
+	// AfterFunc callbacks run in goroutines — give them a moment.
+	require.Eventually(t, func() bool {
+		return notifyCount.Load() == 1
+	}, time.Second, 10*time.Millisecond, "exactly one notification after window expires")
+
+	b.mu.Lock()
+	_, hasTimer := b.timers[uid]
+	_, hasFirstChange := b.firstChange[uid]
+	b.mu.Unlock()
+	assert.False(t, hasTimer, "timer should be cleaned up")
+	assert.False(t, hasFirstChange, "firstChange should be cleaned up")
+}
+
+func TestBatcherScheduleResetsTimer(t *testing.T) {
+	b, fakeClock, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid := types.UID("pod-1")
+
+	b.Schedule(uid)
+	fakeClock.Step(800 * time.Millisecond)
+	assert.Equal(t, int32(0), notifyCount.Load(), "no notification before window")
+
+	// Reset the timer by scheduling again.
+	b.Schedule(uid)
+	fakeClock.Step(800 * time.Millisecond)
+	assert.Equal(t, int32(0), notifyCount.Load(), "timer was reset, still no notification")
+
+	// Window is 1s + up to 200ms jitter from the reset point. Step enough to cover max jitter.
+	fakeClock.Step(500 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return notifyCount.Load() == 1
+	}, time.Second, 10*time.Millisecond, "notification fires after reset window expires")
+}
+
+func TestBatcherMaxCoalesceCap(t *testing.T) {
+	window := 1 * time.Second
+	b, fakeClock, notifyCount := newTestBatcher(t, window)
+
+	uid := types.UID("pod-1")
+
+	b.Schedule(uid)
+
+	// Keep resetting the timer, but the max coalesce cap (3x window) should force a flush.
+	for i := 0; i < 5; i++ {
+		fakeClock.Step(900 * time.Millisecond)
+		if notifyCount.Load() > 0 {
+			break
+		}
+		b.Schedule(uid)
+	}
+
+	require.Eventually(t, func() bool {
+		return notifyCount.Load() >= 1
+	}, time.Second, 10*time.Millisecond, "notification should fire due to max coalesce cap (3x window)")
+}
+
+func TestBatcherFlushImmediate(t *testing.T) {
+	b, _, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid := types.UID("pod-1")
+
+	b.Schedule(uid)
+	assert.Equal(t, int32(0), notifyCount.Load())
+
+	b.Flush(uid)
+	assert.Equal(t, int32(1), notifyCount.Load(), "Flush should notify immediately")
+
+	b.mu.Lock()
+	_, hasTimer := b.timers[uid]
+	_, hasFirstChange := b.firstChange[uid]
+	b.mu.Unlock()
+	assert.False(t, hasTimer, "timer should be cancelled")
+	assert.False(t, hasFirstChange, "firstChange should be cleaned up")
+}
+
+func TestBatcherFlushWithoutSchedule(t *testing.T) {
+	b, _, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid := types.UID("pod-1")
+	b.Flush(uid)
+	assert.Equal(t, int32(1), notifyCount.Load(), "Flush without Schedule should still notify")
+}
+
+func TestBatcherCancel(t *testing.T) {
+	b, fakeClock, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid := types.UID("pod-1")
+
+	b.Schedule(uid)
+	b.Cancel(uid)
+
+	fakeClock.Step(2 * time.Second)
+
+	// Give any goroutine time to fire (it shouldn't).
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(0), notifyCount.Load(), "Cancel should prevent notification")
+
+	b.mu.Lock()
+	_, hasTimer := b.timers[uid]
+	_, hasFirstChange := b.firstChange[uid]
+	b.mu.Unlock()
+	assert.False(t, hasTimer)
+	assert.False(t, hasFirstChange)
+}
+
+func TestBatcherCancelWithoutSchedule(t *testing.T) {
+	b, _, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid := types.UID("pod-1")
+	b.Cancel(uid)
+	assert.Equal(t, int32(0), notifyCount.Load(), "Cancel without Schedule should be a no-op")
+}
+
+func TestBatcherMultiplePods(t *testing.T) {
+	b, fakeClock, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid1 := types.UID("pod-1")
+	uid2 := types.UID("pod-2")
+
+	b.Schedule(uid1)
+	b.Schedule(uid2)
+
+	assert.Equal(t, 2, fakeClock.Waiters(), "two timers should be active")
+
+	fakeClock.Step(1300 * time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return notifyCount.Load() == 2
+	}, time.Second, 10*time.Millisecond, "both pods should notify")
+}
+
+func TestBatcherFlushOneCancelOther(t *testing.T) {
+	b, fakeClock, notifyCount := newTestBatcher(t, 1*time.Second)
+
+	uid1 := types.UID("pod-1")
+	uid2 := types.UID("pod-2")
+
+	b.Schedule(uid1)
+	b.Schedule(uid2)
+
+	b.Flush(uid1)
+	b.Cancel(uid2)
+
+	assert.Equal(t, int32(1), notifyCount.Load(), "only flush should notify")
+
+	fakeClock.Step(2 * time.Second)
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int32(1), notifyCount.Load(), "cancelled pod should not notify")
+}
+
+func TestBatcherDisabledWhenZeroWindow(t *testing.T) {
+	b, _, notifyCount := newTestBatcher(t, 0)
+
+	uid := types.UID("pod-1")
+	b.Schedule(uid)
+
+	// With zero window, Schedule should flush immediately.
+	assert.Equal(t, int32(1), notifyCount.Load(), "zero window should notify immediately")
+}
+
+func TestBatcherJitterRange(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	window := 1 * time.Second
+
+	// Run multiple rounds and verify the timer always fires
+	// within [window, window + 0.2*window] = [1s, 1.2s].
+	for i := 0; i < 10; i++ {
+		notifyCount := &atomic.Int32{}
+		b := newStatusBatcher(fakeClock, window, func() {
+			notifyCount.Add(1)
+		})
+
+		uid := types.UID("pod-jitter")
+		b.Schedule(uid)
+
+		// Advancing by exactly 1s should not always trigger (jitter adds 0-200ms).
+		// But advancing by 1.2s should always trigger.
+		fakeClock.Step(1200 * time.Millisecond)
+		require.Eventually(t, func() bool {
+			return notifyCount.Load() == 1
+		}, time.Second, 10*time.Millisecond, "timer should fire within jitter range (iteration %d)", i)
+	}
+}

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -44,6 +44,7 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeutil "k8s.io/kubernetes/pkg/kubelet/util"
 	statusutil "k8s.io/kubernetes/pkg/util/pod"
+	"k8s.io/utils/clock"
 )
 
 // A wrapper around v1.PodStatus that includes a version to enforce that stale pod statuses are
@@ -79,6 +80,10 @@ type manager struct {
 	podDeletionSafety PodDeletionSafetyProvider
 
 	podStartupLatencyHelper PodStartupLatencyStateHelper
+
+	// batcher debounces pod status updates within a time window.
+	// nil when PodStatusBatchUpdates feature gate is disabled (batchWindow == 0).
+	batcher *statusBatcher
 }
 
 type podResizeConditions struct {
@@ -189,17 +194,27 @@ type Manager interface {
 const syncPeriod = 10 * time.Second
 
 // NewManager returns a functional Manager.
-func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeletionSafety PodDeletionSafetyProvider, podStartupLatencyHelper PodStartupLatencyStateHelper) Manager {
-	return &manager{
+func NewManager(kubeClient clientset.Interface, podManager PodManager, podDeletionSafety PodDeletionSafetyProvider, podStartupLatencyHelper PodStartupLatencyStateHelper, clk clock.WithDelayedExecution, batchWindow time.Duration) Manager {
+	ch := make(chan struct{}, 1)
+	m := &manager{
 		kubeClient:              kubeClient,
 		podManager:              podManager,
 		podStatuses:             make(map[types.UID]versionedPodStatus),
 		podResizeConditions:     make(map[types.UID]podResizeConditions),
-		podStatusChannel:        make(chan struct{}, 1),
+		podStatusChannel:        ch,
 		apiStatusVersions:       make(map[kubetypes.MirrorPodUID]uint64),
 		podDeletionSafety:       podDeletionSafety,
 		podStartupLatencyHelper: podStartupLatencyHelper,
 	}
+	if batchWindow > 0 {
+		m.batcher = newStatusBatcher(clk, batchWindow, func() {
+			select {
+			case ch <- struct{}{}:
+			default:
+			}
+		})
+	}
+	return m
 }
 
 // isPodStatusByKubeletEqual returns true if the given pod statuses are equal when non-kubelet-owned
@@ -895,10 +910,19 @@ func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v
 
 	m.podStatuses[pod.UID] = newStatus
 
-	select {
-	case m.podStatusChannel <- struct{}{}:
-	default:
-		// there's already a status update pending
+	if m.batcher == nil || shouldBypass(forceUpdate, &oldStatus, &status) {
+		if m.batcher != nil {
+			m.batcher.Cancel(pod.UID)
+			reason := bypassReason(forceUpdate, &oldStatus, &status)
+			metrics.PodStatusBatchBypass.WithLabelValues(reason).Inc()
+		}
+		select {
+		case m.podStatusChannel <- struct{}{}:
+		default:
+		}
+	} else {
+		metrics.PodStatusBatchPending.Set(float64(len(m.batcher.timers)))
+		m.batcher.Schedule(pod.UID)
 	}
 }
 
@@ -940,6 +964,9 @@ func (m *manager) RemoveOrphanedStatuses(logger klog.Logger, podUIDs map[types.U
 		if _, ok := podUIDs[key]; !ok {
 			logger.V(5).Info("Removing pod from status map", "podUID", key)
 			delete(m.podStatuses, key)
+			if m.batcher != nil {
+				m.batcher.Cancel(key)
+			}
 			if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 				if _, exists := m.podResizeConditions[key]; exists {
 					delete(m.podResizeConditions, key)

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -921,8 +921,8 @@ func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v
 		default:
 		}
 	} else {
-		metrics.PodStatusBatchPending.Set(float64(len(m.batcher.timers)))
 		m.batcher.Schedule(pod.UID)
+		metrics.PodStatusBatchPending.Set(float64(m.batcher.PendingCount()))
 	}
 }
 
@@ -946,6 +946,9 @@ func (m *manager) deletePodStatus(uid types.UID) {
 	m.podStatusesLock.Lock()
 	defer m.podStatusesLock.Unlock()
 	delete(m.podStatuses, uid)
+	if m.batcher != nil {
+		m.batcher.Cancel(uid)
+	}
 	m.podStartupLatencyHelper.DeletePodStartupState(uid)
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		if _, exists := m.podResizeConditions[uid]; exists {

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -2800,7 +2800,7 @@ func TestBatchingBypassOnPodBecomingReady(t *testing.T) {
 	m.SetPodStatus(logger, pod, ready)
 
 	numUpdates := m.consumeUpdates(ctx)
-	assert.Greater(t, numUpdates, 0, "PodReady transition should bypass batching")
+	assert.Equal(t, 1, numUpdates, "PodReady transition should bypass batching")
 }
 
 func TestBatchingBypassOnPodBecomingUnready(t *testing.T) {
@@ -2830,7 +2830,7 @@ func TestBatchingBypassOnPodBecomingUnready(t *testing.T) {
 	m.SetPodStatus(logger, pod, notReady)
 
 	numUpdates := m.consumeUpdates(ctx)
-	assert.Greater(t, numUpdates, 0, "PodReady→False should bypass batching")
+	assert.Equal(t, 1, numUpdates, "PodReady→False should bypass batching")
 }
 
 func TestBatchingBypassOnTerminalPhase(t *testing.T) {
@@ -2847,7 +2847,7 @@ func TestBatchingBypassOnTerminalPhase(t *testing.T) {
 	m.SetPodStatus(logger, pod, status)
 
 	numUpdates := m.consumeUpdates(ctx)
-	assert.Greater(t, numUpdates, 0, "terminal phase should bypass batching")
+	assert.Equal(t, 1, numUpdates, "terminal phase should bypass batching")
 }
 
 func TestBatchingBypassOnForceUpdate(t *testing.T) {
@@ -2863,7 +2863,7 @@ func TestBatchingBypassOnForceUpdate(t *testing.T) {
 	m.SetPodStatus(logger, pod, status)
 
 	numUpdates := m.consumeUpdates(ctx)
-	assert.Greater(t, numUpdates, 0, "forceUpdate (DeletionTimestamp) should bypass batching")
+	assert.Equal(t, 1, numUpdates, "forceUpdate (DeletionTimestamp) should bypass batching")
 }
 
 func TestBatchingDisabledWithZeroWindow(t *testing.T) {

--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -52,6 +52,8 @@ import (
 	statustest "k8s.io/kubernetes/pkg/kubelet/status/testing"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util"
+	"k8s.io/utils/clock"
+	testingclock "k8s.io/utils/clock/testing"
 )
 
 type mutablePodManager interface {
@@ -97,7 +99,7 @@ func newTestManager(kubeClient clientset.Interface) *manager {
 	podManager := kubepod.NewBasicPodManager()
 	podManager.(mutablePodManager).AddPod(getTestPod())
 	podStartupLatencyTracker := util.NewPodStartupLatencyTracker()
-	return NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker).(*manager)
+	return NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, clock.RealClock{}, 0).(*manager)
 }
 
 func generateRandomMessage() string {
@@ -1112,7 +1114,7 @@ func TestTerminatePod_DefaultUnknownStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			podManager := kubepod.NewBasicPodManager()
 			podStartupLatencyTracker := util.NewPodStartupLatencyTracker()
-			syncer := NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker).(*manager)
+			syncer := NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, clock.RealClock{}, 0).(*manager)
 
 			original := tc.pod.DeepCopy()
 			syncer.SetPodStatus(logger, original, original.Status)
@@ -1201,7 +1203,7 @@ func TestTerminatePod_EnsurePodPhaseIsTerminal(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			podManager := kubepod.NewBasicPodManager()
 			podStartupLatencyTracker := util.NewPodStartupLatencyTracker()
-			syncer := NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker).(*manager)
+			syncer := NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, clock.RealClock{}, 0).(*manager)
 
 			pod := getTestPod()
 			pod.Status = tc.status
@@ -2074,7 +2076,7 @@ func TestMergePodStatus(t *testing.T) {
 }
 
 func TestPodResizeConditions(t *testing.T) {
-	m := NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, util.NewPodStartupLatencyTracker())
+	m := NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, util.NewPodStartupLatencyTracker(), clock.RealClock{}, 0)
 	podUID := types.UID("12345")
 
 	testCases := []struct {
@@ -2275,7 +2277,7 @@ func TestPodResizeConditions(t *testing.T) {
 }
 
 func TestClearPodResizeInProgressCondition(t *testing.T) {
-	m := NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, util.NewPodStartupLatencyTracker())
+	m := NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, util.NewPodStartupLatencyTracker(), clock.RealClock{}, 0)
 	podUID := types.UID("12345")
 
 	testCases := []struct {
@@ -2727,4 +2729,164 @@ func getPodStatus() v1.PodStatus {
 		},
 		Message: "Message",
 	}
+}
+
+func newTestManagerWithBatching(t *testing.T, kubeClient clientset.Interface, batchWindow time.Duration) (*manager, *testingclock.FakeClock) {
+	t.Helper()
+	podManager := kubepod.NewBasicPodManager()
+	podManager.(mutablePodManager).AddPod(getTestPod())
+	podStartupLatencyTracker := util.NewPodStartupLatencyTracker()
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	m := NewManager(kubeClient, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker, fakeClock, batchWindow).(*manager)
+	return m, fakeClock
+}
+
+func TestBatchingCoalescesStatusUpdates(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	client := fake.NewSimpleClientset(getTestPod())
+	m, fakeClock := newTestManagerWithBatching(t, client, 1*time.Second)
+
+	pod := getTestPod()
+
+	status1 := v1.PodStatus{Message: "first"}
+	m.SetPodStatus(logger, pod, status1)
+
+	status2 := v1.PodStatus{Message: "second"}
+	m.SetPodStatus(logger, pod, status2)
+
+	numUpdates := m.consumeUpdates(ctx)
+	assert.Equal(t, 0, numUpdates, "updates should be batched, not sent yet")
+
+	fakeClock.Step(1300 * time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		n := m.consumeUpdates(ctx)
+		return n > 0
+	}, time.Second, 10*time.Millisecond, "batch timer should trigger sync")
+
+	actions := client.Actions()
+	patchCount := 0
+	for _, a := range actions {
+		if a.Matches("patch", "pods") && a.GetSubresource() == "status" {
+			patchCount++
+		}
+	}
+	assert.Equal(t, 1, patchCount, "should coalesce into a single PATCH")
+}
+
+func TestBatchingBypassOnPodBecomingReady(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	client := fake.NewSimpleClientset(getTestPod())
+	m, _ := newTestManagerWithBatching(t, client, 1*time.Second)
+
+	pod := getTestPod()
+
+	notReady := v1.PodStatus{
+		Phase: v1.PodRunning,
+		Conditions: []v1.PodCondition{
+			{Type: v1.PodReady, Status: v1.ConditionFalse},
+		},
+		Message: "not-ready",
+	}
+	m.SetPodStatus(logger, pod, notReady)
+
+	ready := v1.PodStatus{
+		Phase: v1.PodRunning,
+		Conditions: []v1.PodCondition{
+			{Type: v1.PodReady, Status: v1.ConditionTrue},
+		},
+		Message: "ready",
+	}
+	m.SetPodStatus(logger, pod, ready)
+
+	numUpdates := m.consumeUpdates(ctx)
+	assert.Greater(t, numUpdates, 0, "PodReady transition should bypass batching")
+}
+
+func TestBatchingBypassOnPodBecomingUnready(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	client := fake.NewSimpleClientset(getTestPod())
+	m, _ := newTestManagerWithBatching(t, client, 1*time.Second)
+
+	pod := getTestPod()
+
+	ready := v1.PodStatus{
+		Phase: v1.PodRunning,
+		Conditions: []v1.PodCondition{
+			{Type: v1.PodReady, Status: v1.ConditionTrue},
+		},
+	}
+	m.SetPodStatus(logger, pod, ready)
+	m.consumeUpdates(ctx)
+	client.ClearActions()
+
+	notReady := v1.PodStatus{
+		Phase: v1.PodRunning,
+		Conditions: []v1.PodCondition{
+			{Type: v1.PodReady, Status: v1.ConditionFalse},
+		},
+		Message: "crashed",
+	}
+	m.SetPodStatus(logger, pod, notReady)
+
+	numUpdates := m.consumeUpdates(ctx)
+	assert.Greater(t, numUpdates, 0, "PodReady→False should bypass batching")
+}
+
+func TestBatchingBypassOnTerminalPhase(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	client := fake.NewSimpleClientset(getTestPod())
+	m, _ := newTestManagerWithBatching(t, client, 1*time.Second)
+
+	pod := getTestPod()
+
+	status := v1.PodStatus{
+		Phase:   v1.PodFailed,
+		Message: "OOMKilled",
+	}
+	m.SetPodStatus(logger, pod, status)
+
+	numUpdates := m.consumeUpdates(ctx)
+	assert.Greater(t, numUpdates, 0, "terminal phase should bypass batching")
+}
+
+func TestBatchingBypassOnForceUpdate(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	client := fake.NewSimpleClientset(getTestPod())
+	m, _ := newTestManagerWithBatching(t, client, 1*time.Second)
+
+	pod := getTestPod()
+	pod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	m.podManager.(mutablePodManager).UpdatePod(pod)
+
+	status := v1.PodStatus{Message: "deleting"}
+	m.SetPodStatus(logger, pod, status)
+
+	numUpdates := m.consumeUpdates(ctx)
+	assert.Greater(t, numUpdates, 0, "forceUpdate (DeletionTimestamp) should bypass batching")
+}
+
+func TestBatchingDisabledWithZeroWindow(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	syncer := newTestManager(&fake.Clientset{})
+
+	pod := getTestPod()
+	syncer.SetPodStatus(logger, pod, getRandomPodStatus())
+
+	numUpdates := syncer.consumeUpdates(ctx)
+	assert.Equal(t, 1, numUpdates, "zero window should behave like no batching")
+}
+
+func TestBatchingOrphanCleanup(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	m, fakeClock := newTestManagerWithBatching(t, &fake.Clientset{}, 1*time.Second)
+
+	pod := getTestPod()
+	m.SetPodStatus(logger, pod, getRandomPodStatus())
+
+	assert.Equal(t, 1, fakeClock.Waiters(), "timer should be pending")
+
+	m.RemoveOrphanedStatuses(logger, map[types.UID]bool{})
+
+	assert.Equal(t, 0, fakeClock.Waiters(), "timer should be cancelled after orphan removal")
 }

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -832,6 +832,13 @@ type KubeletConfiguration struct {
 	// +featureGate=KubeletCrashLoopBackOffMax
 	// +optional
 	CrashLoopBackOff CrashLoopBackOffConfig `json:"crashLoopBackOff,omitempty"`
+	// podStatusUpdateBatchWindow is the duration to wait before flushing a pod's
+	// status update to the API server, allowing multiple container state changes
+	// to be coalesced into a single update. Zero means disabled.
+	// Minimum 250ms, maximum 5s.
+	// +featureGate=PodStatusBatchUpdates
+	// +optional
+	PodStatusUpdateBatchWindow metav1.Duration `json:"podStatusUpdateBatchWindow,omitempty"`
 	// reservedMemory specifies a comma-separated list of memory reservations for NUMA nodes.
 	// The parameter makes sense only in the context of the memory manager feature.
 	// The memory manager will not allocate reserved memory for container workloads.


### PR DESCRIPTION
Add PodStatusBatchUpdates feature gate to debounce pod status writes

    Kubelet sends a PATCH /pods/status for every container state change,
    creating excessive API server calls and etcd revisions on multi-container
    pods. This adds a configurable debounce window (PodStatusUpdateBatchWindow)
    that coalesces rapid status changes into a single API call.

    Bypass conditions ensure critical transitions are never delayed:
    - PodReady changes in either direction (for endpoint controller)
    - Terminal phase transitions (Failed/Succeeded, for Job controller)
    - Force updates (deletion, termination)
    - Max coalesce cap at 3x window (prevents starvation)

    Alpha feature gate, default off. Default window 1s (range 250ms-5s).