### PR TITLE
fix(kube-apiserver): always refetch JWKS on unknown key ID

### DIFF
--- a/vendor/github.com/coreos/go-oidc/jwks.go
+++ b/vendor/github.com/coreos/go-oidc/jwks.go
@@ -109,7 +109,7 @@ func (r *remoteKeySet) verify(ctx context.Context, jws *jose.JSONWebSignature) (
 		break
 	}
 
-	keys, expiry := r.keysFromCache()
+	keys, _ := r.keysFromCache()
 
 	// Don't check expiry yet. This optimizes for when the provider is unavailable.
 	for _, key := range keys {
@@ -120,11 +120,11 @@ func (r *remoteKeySet) verify(ctx context.Context, jws *jose.JSONWebSignature) (
 		}
 	}
 
-	if !r.now().Add(keysExpiryDelta).After(expiry) {
-		// Keys haven't expired, don't refresh.
-		return nil, errors.New("failed to verify id token signature")
-	}
-
+	// If the kid doesn't match any cached key, always fetch from remote regardless
+	// of cache TTL. The OIDC provider may have added new signing keys since the
+	// last fetch (e.g. EKS returns max-age=604800 but rotates keys within that window).
+	//
+	// https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys
 	keys, err := r.keysFromRemote(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetching keys %v", err)


### PR DESCRIPTION
When a token's kid is absent from the cached JWKS, go-oidc v2 only refetches if the cache-control maxage TTL has expired. EKS sets max-age=604800 (7 days), so new signing keys added by AWS within that window are never picked up, causing CCM and other workloads whose tokens are signed with the new key to fail with "failed to verify id token signature" until the apiserver is restarted.

Fix: discard the cache-TTL guard in verify(). If a kid is not found in the local cache, always attempt a remote fetch. Subsequent tokens signed with cached (old) keys continue to verify without a network roundtrip; only an unknown kid triggers a refetch.

datadog:patch
Origin: https://github.com/coreos/go-oidc/pull/259 Drop-After: when go-oidc is upgraded to v3 (includes this fix natively)