### PR TITLE
noderesources: exempt annotated pods from max-pod-count cap

### DIFF
--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -103,6 +103,7 @@ func (f *Fit) ScoreExtensions() framework.ScoreExtensions {
 // preFilterState computed at PreFilter and used at Filter.
 type preFilterState struct {
 	framework.Resource
+	ExcludeFromPodCount bool // Datadog: **NOT FROM UPSTREAM K8s**
 }
 
 // Clone the prefilter state.
@@ -223,6 +224,7 @@ func computePodResourceRequest(pod *v1.Pod, opts ResourceRequestsOptions) *preFi
 	})
 	result := &preFilterState{}
 	result.SetMaxResource(reqs)
+	result.ExcludeFromPodCount = isExcludedFromMaxPodCount(pod) // Datadog: **NOT FROM UPSTREAM K8s**
 	return result
 }
 
@@ -509,6 +511,7 @@ func fitsRequest(podRequest *preFilterState, nodeInfo *framework.NodeInfo, ignor
 	insufficientResources := make([]InsufficientResource, 0, 4)
 
 	allowedPodNumber := nodeInfo.Allocatable.AllowedPodNumber
+	allowedPodNumber = incrAllowedPodNumberWhenExcludedFromPodCount(allowedPodNumber, podRequest.ExcludeFromPodCount) // Datadog: **NOT FROM UPSTREAM K8s**
 	if len(nodeInfo.Pods)+1 > allowedPodNumber {
 		insufficientResources = append(insufficientResources, InsufficientResource{
 			ResourceName: v1.ResourcePods,

--- a/pkg/scheduler/framework/plugins/noderesources/pod_count_exemption.go
+++ b/pkg/scheduler/framework/plugins/noderesources/pod_count_exemption.go
@@ -1,0 +1,33 @@
+// Datadog: **NOT FROM UPSTREAM K8s**
+
+package noderesources
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	ExcludeFromMaxPodCountAnnotationKey   = "kubelet.datadoghq.com/exclude-from-max-pods"
+	excludeFromMaxPodCountAnnotationValue = "true"
+)
+
+func isExcludedFromMaxPodCount(pod *v1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	// Must be host networked to qualify for exclusion from max pod count.
+	exempt := pod.Spec.HostNetwork &&
+		pod.Annotations[ExcludeFromMaxPodCountAnnotationKey] == excludeFromMaxPodCountAnnotationValue
+	if exempt {
+		klog.V(4).InfoS("pod opted out of max-pod-count cap", "pod", klog.KObj(pod))
+	}
+	return exempt
+}
+
+func incrAllowedPodNumberWhenExcludedFromPodCount(allowedPodNumber int, excludeFromPodCount bool) int {
+	if excludeFromPodCount {
+		return allowedPodNumber + 1
+	}
+	return allowedPodNumber
+}

--- a/pkg/scheduler/framework/plugins/noderesources/pod_count_exemption_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/pod_count_exemption_test.go
@@ -1,0 +1,122 @@
+// Datadog: **NOT FROM UPSTREAM K8s**
+
+package noderesources
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+)
+
+// makeAtCapNodeInfo returns a NodeInfo with maxPods existing pods already scheduled,
+// putting the node at its pod capacity.
+func makeAtCapNodeInfo(maxPods int64) *framework.NodeInfo {
+	var pods []*v1.Pod
+	for range maxPods {
+		pods = append(pods, &v1.Pod{})
+	}
+	ni := framework.NewNodeInfo(pods...)
+	ni.SetNode(&v1.Node{
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(maxPods, resource.DecimalSI),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(maxPods, resource.DecimalSI),
+			},
+		},
+	})
+	return ni
+}
+
+func exemptPod() *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				ExcludeFromMaxPodCountAnnotationKey: "true",
+			},
+		},
+		Spec: v1.PodSpec{HostNetwork: true},
+	}
+}
+
+func TestPodCountExemption(t *testing.T) {
+	const maxPods = 2
+
+	tests := []struct {
+		name        string
+		pod         *v1.Pod
+		wantSuccess bool
+	}{
+		{
+			name:        "non-exempt pod rejected at capacity",
+			pod:         &v1.Pod{},
+			wantSuccess: false,
+		},
+		{
+			name:        "exempt pod (hostNetwork + annotation) accepted at capacity",
+			pod:         exemptPod(),
+			wantSuccess: true,
+		},
+		{
+			name: "wrong annotation value rejected",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ExcludeFromMaxPodCountAnnotationKey: "True",
+					},
+				},
+				Spec: v1.PodSpec{HostNetwork: true},
+			},
+			wantSuccess: false,
+		},
+		{
+			name: "annotation without hostNetwork rejected",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ExcludeFromMaxPodCountAnnotationKey: "true",
+					},
+				},
+			},
+			wantSuccess: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			p, err := NewFit(ctx, &config.NodeResourcesFitArgs{ScoringStrategy: defaultScoringStrategy}, nil, plfeature.Features{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			nodeInfo := makeAtCapNodeInfo(maxPods)
+			cycleState := framework.NewCycleState()
+
+			_, preFilterStatus := p.(framework.PreFilterPlugin).PreFilter(ctx, cycleState, tc.pod, nil)
+			if !preFilterStatus.IsSuccess() {
+				t.Fatalf("PreFilter failed: %v", preFilterStatus)
+			}
+
+			got := p.(framework.FilterPlugin).Filter(ctx, cycleState, tc.pod, nodeInfo)
+			if tc.wantSuccess && !got.IsSuccess() {
+				t.Errorf("expected schedulable, got: %v", got)
+			}
+			if !tc.wantSuccess && got.IsSuccess() {
+				t.Errorf("expected unschedulable, got success")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Datadog: **NOT FROM UPSTREAM K8s**.

Adds a pod-count exemption for pods carrying the annotation kubelet.datadoghq.com/exclude-from-max-pods="true" (literal value, case-sensitive, fail-closed). To be exempt the pod must also be host networked. Exempt pods bypass the v1.ResourcePods / Allocatable.Pods check in fitsRequest but are subject to all other scheduler and kubelet admission checks unchanged.

The exemption is resolved once at PreFilter time via isExcludedFromMaxPodCount (pod_count_exemption.go) and flows through the shared AdmissionCheck seam, so both the scheduler filter path and the kubelet admission path honour it without a kubelet-specific branch.

datadog:patch

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
