### PR TITLE
noderesources: exempt annotated pods from max-pod-count cap

### DIFF
--- a/.gbi
+++ b/.gbi
@@ -1,0 +1,1 @@
+registry.ddbuild.io/images/base/gbi-ubuntu_2404:release@sha256:de9ff286f1a8bde796fc2b4afde9134079d74d90abe8b7b615212838e8fc01fd

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -55,3 +55,8 @@ ADD rsyncd.password /
 RUN chmod a+r /rsyncd.password
 ADD rsyncd.sh /
 RUN chmod a+rx /rsyncd.sh
+
+# Enable fips build
+ENV GOEXPERIMENT=boringcrypto
+# Enable debug to keep symbols around, allowing us to do go tool nm
+ENV DBG=1

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1289,8 +1289,14 @@ func NodeShouldRunDaemonPod(node *v1.Node, ds *apps.DaemonSet) (bool, bool) {
 	}
 
 	taints := node.Spec.Taints
-	fitsNodeName, fitsNodeAffinity, fitsTaints := predicates(pod, node, taints)
-	if !fitsNodeName || !fitsNodeAffinity {
+	fitsNodeName := len(pod.Spec.NodeName) == 0 || pod.Spec.NodeName == node.Name
+	if !fitsNodeName {
+		return false, false
+	}
+
+	fitsNodeName, fitsNodeSelector, fitsNodeAffinity, fitsTaints := predicates(pod, node, taints)
+
+	if !fitsNodeName || !fitsNodeSelector {
 		return false, false
 	}
 
@@ -1302,14 +1308,35 @@ func NodeShouldRunDaemonPod(node *v1.Node, ds *apps.DaemonSet) (bool, bool) {
 		return false, !hasUntoleratedTaint
 	}
 
+	if !fitsNodeAffinity {
+		// IgnoredDuringExecution means that if the node labels change after Kubernetes schedules the Pod, the Pod continues to run.
+		return false, true
+	}
+
 	return true, true
 }
 
 // predicates checks if a DaemonSet's pod can run on a node.
-func predicates(pod *v1.Pod, node *v1.Node, taints []v1.Taint) (fitsNodeName, fitsNodeAffinity, fitsTaints bool) {
+func predicates(pod *v1.Pod, node *v1.Node, taints []v1.Taint) (fitsNodeName, fitsNodeSelector, fitsNodeAffinity, fitsTaints bool) {
 	fitsNodeName = len(pod.Spec.NodeName) == 0 || pod.Spec.NodeName == node.Name
+
+	if len(pod.Spec.NodeSelector) > 0 {
+		selector := labels.SelectorFromSet(pod.Spec.NodeSelector)
+		fitsNodeSelector = selector.Matches(labels.Set(node.Labels))
+	} else {
+		fitsNodeSelector = true
+	}
+
+	if pod.Spec.Affinity != nil &&
+		pod.Spec.Affinity.NodeAffinity != nil &&
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		affinity := nodeaffinity.NewLazyErrorNodeSelector(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+		fitsNodeAffinity, _ = affinity.Match(node)
+	} else {
+		fitsNodeAffinity = true
+	}
+
 	// Ignore parsing errors for backwards compatibility.
-	fitsNodeAffinity, _ = nodeaffinity.GetRequiredNodeAffinity(pod).Match(node)
 	_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
 		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule
 	})

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -920,6 +920,13 @@ func NewMainKubelet(ctx context.Context,
 				}
 				return cert, nil
 			}
+
+			// GetCertificate is only preferred over the certificate files by
+			// Golang TLS if the ClientHelloInfo.ServerName is set, which it is
+			// not when connecting to a host by IP address. Clear the files to
+			// force the use of GetCertificate.
+			kubeDeps.TLSOptions.CertFile = ""
+			kubeDeps.TLSOptions.KeyFile = ""
 		}
 	}
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -123,6 +123,7 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/userns"
 	"k8s.io/kubernetes/pkg/kubelet/util"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/kubelet/util/manager"
 	"k8s.io/kubernetes/pkg/kubelet/util/queue"
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
@@ -2906,6 +2907,8 @@ func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 		// TODO: reconcile being calculated in the config manager is questionable, and avoiding
 		// extra syncs may no longer be necessary. Reevaluate whether Reconcile and Sync can be
 		// merged (after resolving the next two TODOs).
+		sidecarsStatus := status.GetSidecarsStatus(pod)
+		klog.Infof("Pod: %s, status: Present=%v,Ready=%v,ContainersWaiting=%v", format.Pod(pod), sidecarsStatus.SidecarsPresent, sidecarsStatus.SidecarsReady, sidecarsStatus.ContainersWaiting)
 
 		// Reconcile Pod "Ready" condition if necessary. Trigger sync pod for reconciliation.
 		// TODO: this should be unnecessary today - determine what is the cause for this to
@@ -2918,6 +2921,17 @@ func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 				UpdateType: kubetypes.SyncPodSync,
 				StartTime:  start,
 			})
+		} else if sidecarsStatus.ContainersWaiting {
+			// if containers aren't running and the sidecars are all ready trigger a sync so that the containers get started
+			if sidecarsStatus.SidecarsPresent && sidecarsStatus.SidecarsReady {
+				klog.Infof("Pod: %s: sidecars: sidecars are ready, dispatching work", format.Pod(pod))
+				kl.podWorkers.UpdatePod(UpdatePodOptions{
+					Pod:        pod,
+					MirrorPod:  mirrorPod,
+					UpdateType: kubetypes.SyncPodSync,
+					StartTime:  start,
+				})
+			}
 		}
 
 		// After an evicted pod is synced, all dead containers in the pod can be removed.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -787,6 +787,12 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.
 
 	l := getContainerInfoFromLabels(ctx, s.Labels)
 	a := getContainerInfoFromAnnotations(ctx, s.Annotations)
+
+	annotations := make(map[string]string)
+	if a.Sidecar {
+		annotations[fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", l.ContainerName)] = "Sidecar"
+	}
+
 	// Notice that the followings are not full spec. The container killing code should not use
 	// un-restored fields.
 	pod = &v1.Pod{
@@ -795,6 +801,7 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.
 			Name:                       l.PodName,
 			Namespace:                  l.PodNamespace,
 			DeletionGracePeriodSeconds: a.PodDeletionGracePeriod,
+			Annotations:                annotations,
 		},
 		Spec: v1.PodSpec{
 			TerminationGracePeriodSeconds: a.PodTerminationGracePeriod,
@@ -821,8 +828,15 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 	var containerSpec *v1.Container
 	if pod != nil {
 		if containerSpec = kubecontainer.GetContainerSpec(pod, containerName); containerSpec == nil {
-			return fmt.Errorf("failed to get containerSpec %q (id=%q) in pod %q when killing container for reason %q",
-				containerName, containerID.String(), format.Pod(pod), message)
+			// after a kubelet restart, it's not 100% certain that the
+			// pod we're given has the container we need in the spec
+			// -- we try to recover that here.
+			restoredPod, restoredContainer, err := m.restoreSpecsFromContainerLabels(ctx, containerID)
+			if err != nil {
+				return fmt.Errorf("failed to get containerSpec %q(id=%q) in pod %q when killing container for reason %q. error: %v",
+					containerName, containerID.String(), format.Pod(pod), message, err)
+			}
+			pod, containerSpec = restoredPod, restoredContainer
 		}
 	} else {
 		// Restore necessary information if one of the specs is nil.
@@ -886,9 +900,27 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 // killContainersWithSyncResult kills all pod's containers with sync results.
 func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) (syncResults []*kubecontainer.SyncResult) {
 	logger := klog.FromContext(ctx)
-	containerResults := make(chan *kubecontainer.SyncResult, len(runningPod.Containers))
-	wg := sync.WaitGroup{}
+	// split out sidecars and non-sidecars
+	var (
+		sidecars    []*kubecontainer.Container
+		nonSidecars []*kubecontainer.Container
+	)
 
+	if gracePeriodOverride == nil {
+		minGracePeriod := int64(minimumGracePeriodInSeconds)
+		gracePeriodOverride = &minGracePeriod
+	}
+
+	for _, container := range runningPod.Containers {
+		if isSidecar(pod, container.Name) {
+			sidecars = append(sidecars, container)
+		} else {
+			nonSidecars = append(nonSidecars, container)
+		}
+	}
+	containerResults := make(chan *kubecontainer.SyncResult, len(runningPod.Containers))
+
+	wg := sync.WaitGroup{}
 	wg.Add(len(runningPod.Containers))
 	var termOrdering *terminationOrdering
 	if types.HasRestartableInitContainer(pod) {
@@ -898,6 +930,15 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 		}
 		termOrdering = newTerminationOrdering(pod, runningContainerNames)
 	}
+
+	if len(sidecars) > 0 {
+		var runningContainerNames []string
+		for _, container := range runningPod.Containers {
+			runningContainerNames = append(runningContainerNames, container.Name)
+		}
+		termOrdering = lyftSidecarTerminationOrdering(pod, runningContainerNames)
+	}
+
 	for _, container := range runningPod.Containers {
 		go func(container *kubecontainer.Container) {
 			defer utilruntime.HandleCrash()

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -65,6 +65,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
+	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/kubernetes/pkg/kubelet/sysctl"
 	"k8s.io/kubernetes/pkg/kubelet/token"
 	"k8s.io/kubernetes/pkg/kubelet/types"
@@ -620,6 +621,14 @@ func containerResourcesFromRequirements(requirements *v1.ResourceRequirements) c
 	}
 }
 
+func isSidecar(pod *v1.Pod, containerName string) bool {
+	if pod == nil {
+		klog.V(5).Infof("isSidecar: pod is nil, so returning false")
+		return false
+	}
+	return pod.Annotations[fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", containerName)] == "Sidecar"
+}
+
 // computePodResizeAction determines the actions required (if any) to resize the given container.
 // Returns whether to keep (true) or restart (false) the container.
 // TODO(vibansal): Make this function to be agnostic to whether it is dealing with a restartable init container or not (i.e. remove the argument `isRestartableInitContainer`).
@@ -1018,6 +1027,17 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		ContainersToKill:  make(map[kubecontainer.ContainerID]containerToKillInfo),
 	}
 
+	var sidecarNames []string
+	for _, container := range pod.Spec.Containers {
+		if isSidecar(pod, container.Name) {
+			sidecarNames = append(sidecarNames, container.Name)
+		}
+	}
+
+	// determine sidecar status
+	sidecarStatus := status.GetSidecarsStatus(pod)
+	klog.Infof("Pod: %s, sidecars: %s, status: Present=%v,Ready=%v,ContainersWaiting=%v", format.Pod(pod), sidecarNames, sidecarStatus.SidecarsPresent, sidecarStatus.SidecarsReady, sidecarStatus.ContainersWaiting)
+
 	// If we need to (re-)create the pod sandbox, everything will need to be
 	// killed and recreated, and init containers should be purged.
 	if createPodSandbox {
@@ -1077,7 +1097,22 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 
 			return changes
 		}
-		changes.ContainersToStart = containersToStart
+		if len(sidecarNames) > 0 {
+			for idx, c := range pod.Spec.Containers {
+				if isSidecar(pod, c.Name) {
+					changes.ContainersToStart = append(changes.ContainersToStart, idx)
+				}
+			}
+			return changes
+		}
+		// Start all containers by default but exclude the ones that
+		// succeeded if RestartPolicy is OnFailure
+		for idx, c := range pod.Spec.Containers {
+			if containerSucceeded(&c, podStatus) && pod.Spec.RestartPolicy == v1.RestartPolicyOnFailure {
+				continue
+			}
+			changes.ContainersToStart = append(changes.ContainersToStart, idx)
+		}
 		return changes
 	}
 
@@ -1109,6 +1144,21 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	keepCount := 0
 	// check the status of containers.
 	for idx, container := range pod.Spec.Containers {
+		// this works because in other cases, if it was a sidecar, we
+		// are always allowed to handle the container.
+		//
+		// if it is a non-sidecar, and there are no sidecars, then
+		// we're are also always allowed to restart the container.
+		//
+		// if there are sidecars, then we can only restart non-sidecars under
+		// the following conditions:
+		// - the non-sidecars have run before (i.e. they are not in a Waiting state) OR
+		// - the sidecars are ready (we're starting them for the first time)
+		if !isSidecar(pod, container.Name) && sidecarStatus.SidecarsPresent && sidecarStatus.ContainersWaiting && !sidecarStatus.SidecarsReady {
+			klog.Infof("Pod: %s, Container: %s, sidecar=%v skipped: Present=%v,Ready=%v,ContainerWaiting=%v", format.Pod(pod), container.Name, isSidecar(pod, container.Name), sidecarStatus.SidecarsPresent, sidecarStatus.SidecarsReady, sidecarStatus.ContainersWaiting)
+			continue
+		}
+
 		containerStatus := podStatus.FindContainerStatusByName(container.Name)
 
 		// Call internal container post-stop lifecycle hook for any non-running container so that any
@@ -1193,6 +1243,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	}
 
 	if keepCount == 0 && len(changes.ContainersToStart) == 0 {
+		klog.Infof("Pod: %s: KillPod=true", format.Pod(pod))
 		changes.KillPod = true
 		// To prevent the restartable init containers to keep pod alive, we should
 		// not restart them.
@@ -1675,6 +1726,35 @@ func (m *kubeGenericRuntimeManager) doBackOff(ctx context.Context, pod *v1.Pod, 
 // only hard kill paths are allowed to specify a gracePeriodOverride in the kubelet in order to not corrupt user data.
 // it is useful when doing SIGKILL for hard eviction scenarios, or max grace period during soft eviction scenarios.
 func (m *kubeGenericRuntimeManager) KillPod(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+	// if the pod is nil, we need to recover it, so we can get the
+	// grace period and also the sidecar status.
+	if pod == nil {
+		for _, container := range runningPod.Containers {
+			klog.Infof("Pod: %s, KillPod: pod nil, trying to restore from container %s", runningPod.Name, container.ID)
+			podSpec, _, err := m.restoreSpecsFromContainerLabels(ctx, container.ID)
+			if err != nil {
+				klog.Errorf("Pod: %s, KillPod: couldn't restore: %s", runningPod.Name, container.ID)
+				continue
+			}
+			pod = podSpec
+			break
+		}
+	}
+
+	if gracePeriodOverride == nil && pod != nil {
+		switch {
+		case pod.DeletionGracePeriodSeconds != nil:
+			gracePeriodOverride = pod.DeletionGracePeriodSeconds
+		case pod.Spec.TerminationGracePeriodSeconds != nil:
+			gracePeriodOverride = pod.Spec.TerminationGracePeriodSeconds
+		}
+	}
+
+	if gracePeriodOverride == nil || *gracePeriodOverride < minimumGracePeriodInSeconds {
+		min := int64(minimumGracePeriodInSeconds)
+		gracePeriodOverride = &min
+	}
+
 	err := m.killPodWithSyncResult(ctx, pod, runningPod, gracePeriodOverride)
 	return err.Error()
 }

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -192,9 +192,6 @@ func ListenAndServeKubeletServer(
 
 	if tlsOptions != nil {
 		s.TLSConfig = tlsOptions.Config
-		// Passing empty strings as the cert and key files means no
-		// cert/keys are specified and GetCertificate in the TLSConfig
-		// should be called instead.
 		if err := s.ListenAndServeTLS(tlsOptions.CertFile, tlsOptions.KeyFile); err != nil {
 			klog.ErrorS(err, "Failed to listen and serve")
 			os.Exit(1)

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -107,6 +107,7 @@ type preFilterState struct {
 	framework.Resource
 	// resourceToDeviceClass holds the mapping of extended resource to device class name.
 	resourceToDeviceClass map[v1.ResourceName]string
+	ExcludeFromPodCount   bool // Datadog: **NOT FROM UPSTREAM K8s**
 }
 
 // Clone the prefilter state.
@@ -229,6 +230,7 @@ func computePodResourceRequest(pod *v1.Pod, opts ResourceRequestsOptions) *preFi
 	})
 	result := &preFilterState{}
 	result.SetMaxResource(reqs)
+	result.ExcludeFromPodCount = isExcludedFromMaxPodCount(pod) // Datadog: **NOT FROM UPSTREAM K8s**
 	return result
 }
 
@@ -565,6 +567,7 @@ func fitsRequest(podRequest *preFilterState, nodeInfo fwk.NodeInfo, ignoredExten
 	insufficientResources := make([]InsufficientResource, 0, 4)
 
 	allowedPodNumber := nodeInfo.GetAllocatable().GetAllowedPodNumber()
+	allowedPodNumber = incrAllowedPodNumberWhenExcludedFromPodCount(allowedPodNumber, podRequest.ExcludeFromPodCount) // Datadog: **NOT FROM UPSTREAM K8s**
 	if len(nodeInfo.GetPods())+1 > allowedPodNumber {
 		insufficientResources = append(insufficientResources, InsufficientResource{
 			ResourceName: v1.ResourcePods,

--- a/pkg/scheduler/framework/plugins/noderesources/pod_count_exemption.go
+++ b/pkg/scheduler/framework/plugins/noderesources/pod_count_exemption.go
@@ -1,0 +1,33 @@
+// Datadog: **NOT FROM UPSTREAM K8s**
+
+package noderesources
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	ExcludeFromMaxPodCountAnnotationKey   = "kubelet.datadoghq.com/exclude-from-max-pods"
+	excludeFromMaxPodCountAnnotationValue = "true"
+)
+
+func isExcludedFromMaxPodCount(pod *v1.Pod) bool {
+	if pod == nil {
+		return false
+	}
+	// Must be host networked to qualify for exclusion from max pod count.
+	exempt := pod.Spec.HostNetwork &&
+		pod.Annotations[ExcludeFromMaxPodCountAnnotationKey] == excludeFromMaxPodCountAnnotationValue
+	if exempt {
+		klog.V(4).InfoS("pod opted out of max-pod-count cap", "pod", klog.KObj(pod))
+	}
+	return exempt
+}
+
+func incrAllowedPodNumberWhenExcludedFromPodCount(allowedPodNumber int, excludeFromPodCount bool) int {
+	if excludeFromPodCount {
+		return allowedPodNumber + 1
+	}
+	return allowedPodNumber
+}

--- a/pkg/scheduler/framework/plugins/noderesources/pod_count_exemption_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/pod_count_exemption_test.go
@@ -1,0 +1,122 @@
+// Datadog: **NOT FROM UPSTREAM K8s**
+
+package noderesources
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+)
+
+// makeAtCapNodeInfo returns a NodeInfo with maxPods existing pods already scheduled,
+// putting the node at its pod capacity.
+func makeAtCapNodeInfo(maxPods int64) *framework.NodeInfo {
+	var pods []*v1.Pod
+	for range maxPods {
+		pods = append(pods, &v1.Pod{})
+	}
+	ni := framework.NewNodeInfo(pods...)
+	ni.SetNode(&v1.Node{
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(maxPods, resource.DecimalSI),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourcePods: *resource.NewQuantity(maxPods, resource.DecimalSI),
+			},
+		},
+	})
+	return ni
+}
+
+func exemptPod() *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				ExcludeFromMaxPodCountAnnotationKey: "true",
+			},
+		},
+		Spec: v1.PodSpec{HostNetwork: true},
+	}
+}
+
+func TestPodCountExemption(t *testing.T) {
+	const maxPods = 2
+
+	tests := []struct {
+		name        string
+		pod         *v1.Pod
+		wantSuccess bool
+	}{
+		{
+			name:        "non-exempt pod rejected at capacity",
+			pod:         &v1.Pod{},
+			wantSuccess: false,
+		},
+		{
+			name:        "exempt pod (hostNetwork + annotation) accepted at capacity",
+			pod:         exemptPod(),
+			wantSuccess: true,
+		},
+		{
+			name: "wrong annotation value rejected",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ExcludeFromMaxPodCountAnnotationKey: "True",
+					},
+				},
+				Spec: v1.PodSpec{HostNetwork: true},
+			},
+			wantSuccess: false,
+		},
+		{
+			name: "annotation without hostNetwork rejected",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ExcludeFromMaxPodCountAnnotationKey: "true",
+					},
+				},
+			},
+			wantSuccess: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			p, err := NewFit(ctx, &config.NodeResourcesFitArgs{ScoringStrategy: defaultScoringStrategy}, nil, plfeature.Features{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			nodeInfo := makeAtCapNodeInfo(maxPods)
+			cycleState := framework.NewCycleState()
+
+			_, preFilterStatus := p.(framework.PreFilterPlugin).PreFilter(ctx, cycleState, tc.pod, nil)
+			if !preFilterStatus.IsSuccess() {
+				t.Fatalf("PreFilter failed: %v", preFilterStatus)
+			}
+
+			got := p.(framework.FilterPlugin).Filter(ctx, cycleState, tc.pod, nodeInfo)
+			if tc.wantSuccess && !got.IsSuccess() {
+				t.Errorf("expected schedulable, got: %v", got)
+			}
+			if !tc.wantSuccess && got.IsSuccess() {
+				t.Errorf("expected unschedulable, got success")
+			}
+		})
+	}
+}

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -32,23 +32,17 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/kubelet/events"
-	"k8s.io/kubernetes/test/e2e/feature"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	admissionapi "k8s.io/pod-security-admission/api"
-	"k8s.io/utils/ptr"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -228,494 +222,127 @@ var _ = SIGDescribe("Pods Extended", func() {
 		})
 	})
 
-	ginkgo.Describe("Pod Container lifecycle", func() {
-		var podClient *e2epod.PodClient
-		ginkgo.BeforeEach(func() {
-			podClient = e2epod.NewPodClient(f)
-		})
+	/*
+		// For now the a2a9964a66ef481d10db3ffc15d4b26a234d0bdd fix isn't compatible with
+		// the sidecar patchset we keep in this fork. Comment out related tests.
+		ginkgo.Describe("Pod Container lifecycle", func() {
+			var podClient *e2epod.PodClient
+			ginkgo.BeforeEach(func() {
+				podClient = e2epod.NewPodClient(f)
+			})
 
-		ginkgo.It("should not create extra sandbox if all containers are done", func(ctx context.Context) {
-			ginkgo.By("creating the pod that should always exit 0")
+			ginkgo.It("should not create extra sandbox if all containers are done", func() {
+				ginkgo.By("creating the pod that should always exit 0")
 
-			name := "pod-always-succeed" + string(uuid.NewUUID())
-			image := imageutils.GetE2EImage(imageutils.BusyBox)
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					InitContainers: []v1.Container{
-						{
-							Name:  "foo",
-							Image: image,
-							Command: []string{
-								"/bin/true",
-							},
-						},
+				name := "pod-always-succeed" + string(uuid.NewUUID())
+				image := imageutils.GetE2EImage(imageutils.BusyBox)
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
 					},
-					Containers: []v1.Container{
-						{
-							Name:  "bar",
-							Image: image,
-							Command: []string{
-								"/bin/true",
-							},
-						},
-					},
-				},
-			}
-
-			ginkgo.By("submitting the pod to kubernetes")
-			createdPod := podClient.Create(ctx, pod)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-			})
-
-			framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
-
-			var eventList *v1.EventList
-			var err error
-			ginkgo.By("Getting events about the pod")
-			framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
-				selector := fields.Set{
-					"involvedObject.kind":      "Pod",
-					"involvedObject.uid":       string(createdPod.UID),
-					"involvedObject.namespace": f.Namespace.Name,
-					"source":                   "kubelet",
-				}.AsSelector().String()
-				options := metav1.ListOptions{FieldSelector: selector}
-				eventList, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, options)
-				if err != nil {
-					return false, err
-				}
-				if len(eventList.Items) > 0 {
-					return true, nil
-				}
-				return false, nil
-			}))
-
-			ginkgo.By("Checking events about the pod")
-			for _, event := range eventList.Items {
-				if event.Reason == events.SandboxChanged {
-					framework.Fail("Unexpected SandboxChanged event")
-				}
-			}
-		})
-
-		ginkgo.It("evicted pods should be terminal", func(ctx context.Context) {
-			ginkgo.By("creating the pod that should be evicted")
-
-			name := "pod-should-be-evicted" + string(uuid.NewUUID())
-			image := imageutils.GetE2EImage(imageutils.BusyBox)
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					Containers: []v1.Container{
-						{
-							Name:  "bar",
-							Image: image,
-							Command: []string{
-								"/bin/sh", "-c", "sleep 10; dd if=/dev/zero of=file bs=1M count=10; sleep 10000",
-							},
-							Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{
-									"ephemeral-storage": resource.MustParse("5Mi"),
-								},
-							}},
-					},
-				},
-			}
-
-			ginkgo.By("submitting the pod to kubernetes")
-			podClient.Create(ctx, pod)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-			})
-
-			err := e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, pod.Name, "Evicted", f.Namespace.Name)
-			if err != nil {
-				framework.Failf("error waiting for pod to be evicted: %v", err)
-			}
-
-		})
-	})
-
-	ginkgo.Describe("Pod TerminationGracePeriodSeconds is negative", func() {
-		var podClient *e2epod.PodClient
-		ginkgo.BeforeEach(func() {
-			podClient = e2epod.NewPodClient(f)
-		})
-
-		ginkgo.It("pod with negative grace period", func(ctx context.Context) {
-			name := "pod-negative-grace-period" + string(uuid.NewUUID())
-			image := imageutils.GetE2EImage(imageutils.BusyBox)
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					Containers: []v1.Container{
-						{
-							Name:  "foo",
-							Image: image,
-							Command: []string{
-								"/bin/sh", "-c", "sleep 10000",
-							},
-						},
-					},
-					TerminationGracePeriodSeconds: ptr.To[int64](-1),
-				},
-			}
-
-			ginkgo.By("submitting the pod to kubernetes")
-			podClient.Create(ctx, pod)
-
-			pod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err, "failed to query for pod")
-
-			if pod.Spec.TerminationGracePeriodSeconds == nil {
-				framework.Failf("pod spec TerminationGracePeriodSeconds is nil")
-			}
-
-			if *pod.Spec.TerminationGracePeriodSeconds != 1 {
-				framework.Failf("pod spec TerminationGracePeriodSeconds is not 1: %d", *pod.Spec.TerminationGracePeriodSeconds)
-			}
-
-			// retry if the TerminationGracePeriodSeconds is overrided
-			// see more in https://github.com/kubernetes/kubernetes/pull/115606
-			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				pod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-				framework.ExpectNoError(err, "failed to query for pod")
-				ginkgo.By("updating the pod to have a negative TerminationGracePeriodSeconds")
-				pod.Spec.TerminationGracePeriodSeconds = ptr.To[int64](-1)
-				_, err = podClient.PodInterface.Update(ctx, pod, metav1.UpdateOptions{})
-				return err
-			})
-			framework.ExpectNoError(err, "failed to update pod")
-
-			pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err, "failed to query for pod")
-
-			if pod.Spec.TerminationGracePeriodSeconds == nil {
-				framework.Failf("pod spec TerminationGracePeriodSeconds is nil")
-			}
-
-			if *pod.Spec.TerminationGracePeriodSeconds != 1 {
-				framework.Failf("pod spec TerminationGracePeriodSeconds is not 1: %d", *pod.Spec.TerminationGracePeriodSeconds)
-			}
-
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-			})
-		})
-	})
-})
-
-var _ = SIGDescribe("Pods Extended (pod generation)", feature.PodObservedGenerationTracking, framework.WithFeatureGate(features.PodObservedGenerationTracking), func() {
-	f := framework.NewDefaultFramework("pods")
-	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
-
-	ginkgo.Describe("Pod Generation", func() {
-		var podClient *e2epod.PodClient
-		ginkgo.BeforeEach(func() {
-			podClient = e2epod.NewPodClient(f)
-		})
-
-		ginkgo.It("pod generation should start at 1 and increment per update", func(ctx context.Context) {
-			ginkgo.By("creating the pod")
-			podName := "pod-generation-" + string(uuid.NewUUID())
-			pod := e2epod.NewAgnhostPod(f.Namespace.Name, podName, nil, nil, nil)
-			pod.Spec.InitContainers = []v1.Container{{
-				Name:  "init-container",
-				Image: imageutils.GetE2EImage(imageutils.BusyBox),
-			}}
-
-			ginkgo.By("submitting the pod to kubernetes")
-			pod = podClient.CreateSync(ctx, pod)
-			gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(1))
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-			})
-
-			ginkgo.By("verifying pod generation bumps as expected")
-			tests := []struct {
-				name                 string
-				updateFn             func(*v1.Pod)
-				expectGenerationBump bool
-			}{
-				{
-					name:                 "empty update",
-					updateFn:             func(pod *v1.Pod) {},
-					expectGenerationBump: false,
-				},
-
-				{
-					name: "updating Tolerations to trigger generation bump",
-					updateFn: func(pod *v1.Pod) {
-						pod.Spec.Tolerations = []v1.Toleration{
+					Spec: v1.PodSpec{
+						RestartPolicy: v1.RestartPolicyOnFailure,
+						InitContainers: []v1.Container{
 							{
-								Key:      "foo-" + string(uuid.NewUUID()),
-								Operator: v1.TolerationOpEqual,
-								Value:    "bar",
-								Effect:   v1.TaintEffectNoSchedule,
+								Name:  "foo",
+								Image: image,
+								Command: []string{
+									"/bin/true",
+								},
 							},
-						}
-					},
-					expectGenerationBump: true,
-				},
-
-				{
-					name: "updating ActiveDeadlineSeconds to trigger generation bump",
-					updateFn: func(pod *v1.Pod) {
-						int5000 := int64(5000)
-						pod.Spec.ActiveDeadlineSeconds = &int5000
-					},
-					expectGenerationBump: true,
-				},
-
-				{
-					name: "updating container image to trigger generation bump",
-					updateFn: func(pod *v1.Pod) {
-						pod.Spec.Containers[0].Image = imageutils.GetE2EImage(imageutils.Nginx)
-					},
-					expectGenerationBump: true,
-				},
-
-				{
-					name: "updating initContainer image to trigger generation bump",
-					updateFn: func(pod *v1.Pod) {
-						pod.Spec.InitContainers[0].Image = imageutils.GetE2EImage(imageutils.Pause)
-					},
-					expectGenerationBump: true,
-				},
-
-				{
-					name: "updates to pod metadata should not trigger generation bump",
-					updateFn: func(pod *v1.Pod) {
-						pod.SetAnnotations(map[string]string{"key": "value"})
-					},
-					expectGenerationBump: false,
-				},
-
-				{
-					name: "pod generation updated by client should be ignored",
-					updateFn: func(pod *v1.Pod) {
-						pod.SetGeneration(1)
-					},
-					expectGenerationBump: false,
-				},
-			}
-
-			expectedPodGeneration := int64(1)
-			for _, test := range tests {
-				ginkgo.By(test.name)
-				podClient.Update(ctx, podName, test.updateFn)
-				pod, err := podClient.Get(ctx, podName, metav1.GetOptions{})
-				framework.ExpectNoError(err, "failed to query for pod")
-				if test.expectGenerationBump {
-					expectedPodGeneration++
-				}
-				gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(expectedPodGeneration))
-				framework.ExpectNoError(e2epod.WaitForPodObservedGeneration(ctx, f.ClientSet, f.Namespace.Name, pod.Name, expectedPodGeneration, 20*time.Second))
-			}
-		})
-
-		ginkgo.It("custom-set generation on new pods and graceful delete", func(ctx context.Context) {
-			ginkgo.By("creating the pod")
-			name := "pod-generation-" + string(uuid.NewUUID())
-			value := strconv.Itoa(time.Now().Nanosecond())
-			pod := e2epod.NewAgnhostPod(f.Namespace.Name, name, nil, nil, nil)
-			pod.ObjectMeta.Labels = map[string]string{
-				"time": value,
-			}
-			pod.SetGeneration(100)
-
-			ginkgo.By("submitting the pod to kubernetes")
-			pod = podClient.CreateSync(ctx, pod)
-
-			ginkgo.By("verifying the new pod's generation is 1")
-			gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(1))
-
-			ginkgo.By("issue a graceful delete to trigger generation bump")
-			// We need to wait for the pod to be running, otherwise the deletion
-			// may be carried out immediately rather than gracefully.
-			framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
-			pod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err, "failed to GET scheduled pod")
-
-			var lastPod v1.Pod
-			var statusCode int
-			// Set gracePeriodSeconds to 60 to give us time to verify the generation bump.
-			err = f.ClientSet.CoreV1().RESTClient().Delete().AbsPath("/api/v1/namespaces", pod.Namespace, "pods", pod.Name).Param("gracePeriodSeconds", "60").Do(ctx).StatusCode(&statusCode).Into(&lastPod)
-			framework.ExpectNoError(err, "failed to use http client to send delete")
-			gomega.Expect(statusCode).To(gomega.Equal(http.StatusOK), "failed to delete gracefully by client request")
-
-			ginkgo.By("verifying the pod generation was bumped")
-			pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err, "failed to query for pod")
-			gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(2))
-		})
-
-		ginkgo.It("issue 500 podspec updates and verify generation and observedGeneration eventually converge", func(ctx context.Context) {
-			ginkgo.By("creating the pod")
-			name := "pod-generation-" + string(uuid.NewUUID())
-			value := strconv.Itoa(time.Now().Nanosecond())
-			pod := e2epod.NewAgnhostPod(f.Namespace.Name, name, nil, nil, nil)
-			pod.ObjectMeta.Labels = map[string]string{
-				"time": value,
-			}
-			pod.Spec.ActiveDeadlineSeconds = ptr.To[int64](5000)
-
-			ginkgo.By("submitting the pod to kubernetes")
-			pod = podClient.CreateSync(ctx, pod)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-			})
-
-			for i := 0; i < 499; i++ {
-				podClient.Update(ctx, pod.Name, func(pod *v1.Pod) {
-					*pod.Spec.ActiveDeadlineSeconds--
-				})
-			}
-
-			// Verify pod observedGeneration converges to the expected generation.
-			expectedPodGeneration := int64(500)
-			framework.ExpectNoError(e2epod.WaitForPodObservedGeneration(ctx, f.ClientSet, f.Namespace.Name, pod.Name, expectedPodGeneration, 30*time.Second))
-
-			// Verify pod generation converges to the expected generation.
-			pod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err, "failed to query for pod")
-			gomega.Expect(pod.Generation).To(gomega.BeEquivalentTo(expectedPodGeneration))
-		})
-
-		// This is the same test as https://github.com/kubernetes/kubernetes/blob/aa08c90fca8d30038d3f05c0e8f127b540b40289/test/e2e/node/pod_admission.go#L35,
-		// except that this verifies the pod generation and observedGeneration, which is
-		// currently behind a feature gate. When we GA observedGeneration functionality,
-		// we can fold these tests together into one.
-		ginkgo.It("pod rejected by kubelet should have updated generation and observedGeneration", func(ctx context.Context) {
-			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-			framework.ExpectNoError(err, "Failed to get a ready schedulable node")
-
-			// Create a pod that requests more CPU than the node has.
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "pod-out-of-cpu",
-					Namespace: f.Namespace.Name,
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:  "pod-out-of-cpu",
-							Image: imageutils.GetPauseImageName(),
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU: resource.MustParse("1000000000000"), // requests more CPU than any node has
+						},
+						Containers: []v1.Container{
+							{
+								Name:  "bar",
+								Image: image,
+								Command: []string{
+									"/bin/true",
 								},
 							},
 						},
 					},
-				},
-			}
+				}
 
-			ginkgo.By("submitting the pod to kubernetes")
-			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				ginkgo.By("submitting the pod to kubernetes")
+				createdPod := podClient.Create(pod)
+				defer func() {
+					ginkgo.By("deleting the pod")
+					podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				}()
+
+				framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name))
+
+				var eventList *v1.EventList
+				var err error
+				ginkgo.By("Getting events about the pod")
+				framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
+					selector := fields.Set{
+						"involvedObject.kind":      "Pod",
+						"involvedObject.uid":       string(createdPod.UID),
+						"involvedObject.namespace": f.Namespace.Name,
+						"source":                   "kubelet",
+					}.AsSelector().String()
+					options := metav1.ListOptions{FieldSelector: selector}
+					eventList, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), options)
+					if err != nil {
+						return false, err
+					}
+					if len(eventList.Items) > 0 {
+						return true, nil
+					}
+					return false, nil
+				}))
+
+				ginkgo.By("Checking events about the pod")
+				for _, event := range eventList.Items {
+					if event.Reason == events.SandboxChanged {
+						framework.Fail("Unexpected SandboxChanged event")
+					}
+				}
 			})
 
-			// Wait for the scheduler to update the pod status
-			err = e2epod.WaitForPodNameUnschedulableInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace)
-			framework.ExpectNoError(err)
+			ginkgo.It("evicted pods should be terminal", func() {
+				ginkgo.By("creating the pod that should be evicted")
 
-			// Fetch the pod to verify that the scheduler has set the PodScheduled condition
-			// with observedGeneration.
-			pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			gomega.Expect(len(pod.Status.Conditions)).To(gomega.BeEquivalentTo(1))
-			gomega.Expect(pod.Status.Conditions[0].Type).To(gomega.BeEquivalentTo(v1.PodScheduled))
-			gomega.Expect(pod.Status.Conditions[0].ObservedGeneration).To(gomega.BeEquivalentTo(1))
+				name := "pod-should-be-evicted" + string(uuid.NewUUID())
+				image := imageutils.GetE2EImage(imageutils.BusyBox)
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+					Spec: v1.PodSpec{
+						RestartPolicy: v1.RestartPolicyOnFailure,
+						Containers: []v1.Container{
+							{
+								Name:  "bar",
+								Image: image,
+								Command: []string{
+									"/bin/sh", "-c", "sleep 10; dd if=/dev/zero of=file bs=1M count=10; sleep 10000",
+								},
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"ephemeral-storage": resource.MustParse("5Mi"),
+									},
+								}},
+						},
+					},
+				}
 
-			// Force assign the Pod to a node in order to get rejection status.
-			binding := &v1.Binding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      pod.Name,
-					Namespace: pod.Namespace,
-					UID:       pod.UID,
-				},
-				Target: v1.ObjectReference{
-					Kind: "Node",
-					Name: node.Name,
-				},
-			}
-			framework.ExpectNoError(f.ClientSet.CoreV1().Pods(pod.Namespace).Bind(ctx, binding, metav1.CreateOptions{}))
+				ginkgo.By("submitting the pod to kubernetes")
+				podClient.Create(pod)
+				defer func() {
+					ginkgo.By("deleting the pod")
+					podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				}()
 
-			// Kubelet has rejected the pod.
-			err = e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, "OutOfcpu", f.Timeouts.PodStart)
-			framework.ExpectNoError(err)
+				err := e2epod.WaitForPodTerminatedInNamespace(f.ClientSet, pod.Name, "Evicted", f.Namespace.Name)
+				if err != nil {
+					framework.Failf("error waiting for pod to be evicted: %v", err)
+				}
 
-			// Fetch the rejected Pod and verify the generation and observedGeneration.
-			gotPod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
-			gomega.Expect(gotPod.Generation).To(gomega.BeEquivalentTo(1))
-			gomega.Expect(gotPod.Status.ObservedGeneration).To(gomega.BeEquivalentTo(1))
+			})
 		})
-
-		ginkgo.It("pod observedGeneration field set in pod conditions", func(ctx context.Context) {
-			ginkgo.By("creating the pod")
-			name := "pod-generation-" + string(uuid.NewUUID())
-			pod := e2epod.NewAgnhostPod(f.Namespace.Name, name, nil, nil, nil)
-
-			// Set the pod image to something that doesn't exist to induce a pull error
-			// to start with.
-			agnImage := pod.Spec.Containers[0].Image
-			pod.Spec.Containers[0].Image = "some-image-that-doesnt-exist"
-
-			ginkgo.By("submitting the pod to kubernetes")
-			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-			})
-
-			expectedPodConditions := []v1.PodConditionType{
-				v1.PodReadyToStartContainers,
-				v1.PodInitialized,
-				v1.PodReady,
-				v1.ContainersReady,
-				v1.PodScheduled,
-			}
-
-			ginkgo.By("verifying the pod conditions have observedGeneration values")
-			expectedObservedGeneration := int64(1)
-			for _, condition := range expectedPodConditions {
-				framework.ExpectNoError(e2epod.WaitForPodConditionObservedGeneration(ctx, f.ClientSet, f.Namespace.Name, pod.Name, condition, expectedObservedGeneration, 30*time.Second))
-			}
-
-			ginkgo.By("updating pod to have a valid image")
-			podClient.Update(ctx, pod.Name, func(pod *v1.Pod) {
-				pod.Spec.Containers[0].Image = agnImage
-			})
-			expectedObservedGeneration++
-
-			ginkgo.By("verifying the pod conditions have updated observedGeneration values")
-			for _, condition := range expectedPodConditions {
-				framework.ExpectNoError(e2epod.WaitForPodConditionObservedGeneration(ctx, f.ClientSet, f.Namespace.Name, pod.Name, condition, expectedObservedGeneration, 30*time.Second))
-			}
-		})
-	})
+	*/
 })
 
 var _ = SIGDescribe("Pod Extended (container restart policy)", framework.WithFeatureGate(features.ContainerRestartRules), func() {

--- a/test/e2e_node/kubelet_tls_test.go
+++ b/test/e2e_node/kubelet_tls_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/kubernetes/pkg/cluster/ports"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func createCertAndKeyFiles(certDir string) (string, string, error) {
+	cert, key, err := cert.GenerateSelfSignedCertKey(
+		"localhost",
+		[]net.IP{{127, 0, 0, 1}},
+		[]string{"localhost"},
+	)
+	if err != nil {
+		return "", "", nil
+	}
+
+	certPath := filepath.Join(certDir, "kubelet.cert")
+	keyPath := filepath.Join(certDir, "kubelet.key")
+	if err = os.WriteFile(certPath, cert, os.FileMode(0644)); err != nil {
+		return "", "", err
+	}
+
+	if err = os.WriteFile(keyPath, key, os.FileMode(0600)); err != nil {
+		return "", "", err
+	}
+
+	return certPath, keyPath, nil
+}
+
+func getCert(addr string) (*x509.Certificate, error) {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	return conn.ConnectionState().PeerCertificates[0], nil
+}
+
+var _ = SIGDescribe("KubletTLS", framework.WithSerial(), framework.WithNodeConformance(), func() {
+	f := framework.NewDefaultFramework("kubelet-tls-test")
+
+	ginkgo.Context("certificate reload", func() {
+		var tempDir string
+
+		t := ginkgo.GinkgoT()
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			tempDir = t.TempDir()
+			cfg, err := getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func(ctx context.Context, cfg *kubeletconfig.KubeletConfiguration) {
+				updateKubeletConfig(ctx, f, cfg, true)
+			}, cfg.DeepCopy())
+
+			certPath, keyPath, err := createCertAndKeyFiles(tempDir)
+			framework.ExpectNoError(err)
+
+			cfg.TLSCertFile = certPath
+			cfg.TLSPrivateKeyFile = keyPath
+			updateKubeletConfig(ctx, f, cfg, true)
+		})
+
+		ginkgo.It("should reload certificates from disk", func(ctx context.Context) {
+			addr := fmt.Sprintf("127.0.0.1:%d", ports.KubeletPort)
+			oldCert, err := getCert(addr)
+			framework.ExpectNoError(err)
+
+			_, _, err = createCertAndKeyFiles(tempDir)
+			framework.ExpectNoError(err)
+
+			gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
+				newCert, err := getCert(addr)
+				if err != nil {
+					return true, err
+				}
+
+				return newCert.Equal(oldCert), nil
+			}).Should(gomega.BeFalseBecause("new certificate should be loaded"))
+		})
+	})
+})

--- a/vendor/github.com/coreos/go-oidc/jwks.go
+++ b/vendor/github.com/coreos/go-oidc/jwks.go
@@ -109,7 +109,7 @@ func (r *remoteKeySet) verify(ctx context.Context, jws *jose.JSONWebSignature) (
 		break
 	}
 
-	keys, expiry := r.keysFromCache()
+	keys, _ := r.keysFromCache()
 
 	// Don't check expiry yet. This optimizes for when the provider is unavailable.
 	for _, key := range keys {
@@ -120,11 +120,11 @@ func (r *remoteKeySet) verify(ctx context.Context, jws *jose.JSONWebSignature) (
 		}
 	}
 
-	if !r.now().Add(keysExpiryDelta).After(expiry) {
-		// Keys haven't expired, don't refresh.
-		return nil, errors.New("failed to verify id token signature")
-	}
-
+	// If the kid doesn't match any cached key, always fetch from remote regardless
+	// of cache TTL. The OIDC provider may have added new signing keys since the
+	// last fetch (e.g. EKS returns max-age=604800 but rotates keys within that window).
+	//
+	// https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys
 	keys, err := r.keysFromRemote(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetching keys %v", err)


### PR DESCRIPTION
Datadog: **NOT FROM UPSTREAM K8s**.

The purpose of this draft PR is to display testing evidence for a custom patch on 1.34 I'm working on.

I tested the PR using kind

## Get the current number of pods on the kind node and fill it to the max with filler pods

```
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ CURRENT=$(kubectl get pods -A --field-selector spec.nodeName=pod-exemption-worker --no-headers | wc -l | tr -d ' ')
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ REPLICAS=$((10 - CURRENT))
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ kubectl apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: filler
spec:
  replicas: $REPLICAS
  selector:
    matchLabels:
      app: filler
  template:
    metadata:
      labels:
        app: filler
    spec:
      nodeSelector:
        kubernetes.io/hostname: pod-exemption-worker
      tolerations:
        - operator: Exists
      containers:
        - name: pause
          image: registry.k8s.io/pause:3.9
          resources:
            requests:
              cpu: 1m
              memory: 1Mi
EOF
deployment.apps/filler created
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ kubectl rollout status deployment/filler --timeout=60s
deployment "filler" successfully rolled out
```

## Test that non-exempt pods are not scheduled

```
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ kubectl run canary --image=registry.k8s.io/pause:3.9 \
  --overrides='{"spec":{"nodeSelector":{"kubernetes.io/hostname":"pod-exemption-worker"}}}'
pod/canary created
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ kubectl describe pod canary | grep -A5 Events
Events:
  Type     Reason            Age   From               Message
  ----     ------            ----  ----               -------
  Warning  FailedScheduling  10s   default-scheduler  0/2 nodes are available: 1 Too many pods, 1 node(s) had untolerated taint(s). no new claims to deallocate, preemption: 0/2 nodes are available: 1 No preemption victims found for incoming pod, 1 Preemption is not helpful for scheduling.
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ k delete pod canary
pod "canary" deleted from default namespace
```

## Test that exempt pods get scheduled

```
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: exempt
  annotations:
    kubelet.datadoghq.com/exclude-from-max-pods: "true"
spec:
  hostNetwork: true
  nodeSelector:
    kubernetes.io/hostname: pod-exemption-worker
  containers:
    - name: pause
      image: registry.k8s.io/pause:3.9
EOF
pod/exempt created
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ kubectl wait pod/exempt --for=condition=Ready --timeout=30s
pod/exempt condition met
➜  kubernetes git:(ea/max-pod-count-exemption-v1.34) ✗ k get pod exempt -o wide
NAME     READY   STATUS    RESTARTS   AGE   IP           NODE                   NOMINATED NODE   READINESS GATES
exempt   1/1     Running   0          24s   172.18.0.3   pod-exemption-worker   <none>           <none>
```
