### PR TITLE
fix(apiserver): cache unstructured conversions across VAP CEL passes and bound policies

### DIFF
--- a/.gbi
+++ b/.gbi
@@ -1,0 +1,1 @@
+registry.ddbuild.io/images/base/gbi-ubuntu_2404:release@sha256:de9ff286f1a8bde796fc2b4afde9134079d74d90abe8b7b615212838e8fc01fd

--- a/.github/chainguard/compute-delivery.sts.yaml
+++ b/.github/chainguard/compute-delivery.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/kubernetes:ref_type:tag:ref:[vw].+"
+
+permissions:
+  contents: write

--- a/.github/workflows/dd-build.yml
+++ b/.github/workflows/dd-build.yml
@@ -1,0 +1,136 @@
+name: Build and Push k8s Release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    tags:
+    # Push events on datadog tags
+    - "*-dd*"
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ["linux/arm64","linux/amd64"]
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        fetch-depth: 0
+    - name: Set up Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+      with:
+        go-version: 1.26
+    - name: Set env
+      run: echo SANITIZED_TARGET_PLATFORM=${KUBE_BUILD_PLATFORM/\//-} >> $GITHUB_ENV
+      env:
+        KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
+    - name: Cleanup disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/local/.ghcup
+    - name: Build
+      env:
+        GOFLAGS: "-tags=fips"
+        KUBE_BUILD_PLATFORMS: ${{ matrix.platform }}
+        KUBE_RELEASE_RUN_TESTS: n
+      run: make quick-release CGO_ENABLED=1 KUBE_CGO_OVERRIDES="kube-apiserver kube-controller-manager kube-scheduler kubelet" KUBE_BUILD_PLATFORMS=$KUBE_BUILD_PLATFORMS GOFLAGS=$GOFLAGS
+    - name: Calculate checksums
+      id: calculate_checksums
+      shell: bash
+      working-directory: _output/release-tars
+      env:
+        KUBE_BUILD_PLATFORM: ${{ matrix.platform }}
+      run: |
+        TARGET_PLATFORM="${KUBE_BUILD_PLATFORM/\//-}"
+        for TARGET_FILE in *"${TARGET_PLATFORM}".tar.gz
+        do
+          sha256sum "$TARGET_FILE" > "${TARGET_FILE}.sha256sum"
+        done
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: k8s_output_${{ env.SANITIZED_TARGET_PLATFORM }}
+        path: _output/release-tars
+      env:
+        SANITIZED_TARGET_PLATFORM: ${{ env.SANITIZED_TARGET_PLATFORM }}
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: build
+    outputs:
+      upload_url: ${{ steps.create_release_branch.outputs.upload_url }}${{ steps.create_release_tags.outputs.upload_url }}
+    steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: extract_branch
+      env:
+        GITHUB_REF: ${{ github.ref }}
+      if: startsWith(github.ref, 'refs/heads/')
+    - name: Create Release for Branch
+      id: create_release_branch
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+      if: startsWith(github.ref, 'refs/heads/')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: branch@${{ steps.extract_branch.outputs.branch  }}
+        tag_name: branch@${{ steps.extract_branch.outputs.branch  }}
+        draft: false
+        prerelease: false
+    - name: Extract tags name
+      shell: bash
+      run: echo "##[set-output name=tags;]$(echo ${GITHUB_REF#refs/tags/})"
+      id: extract_tags
+      env:
+        GITHUB_REF: ${{ github.ref }}
+      if: startsWith(github.ref, 'refs/tags/')
+    - name: Create Release for Tags
+      id: create_release_tags
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: ${{ steps.extract_tags.outputs.tags }}
+        tag_name: ${{ steps.extract_tags.outputs.tags }}
+        release_name: ${{ steps.extract_tags.outputs.tags }}
+        draft: false
+        prerelease: false
+  releaseassetsarm:
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        assets: [
+           "kubernetes-client",
+           "kubernetes-node",
+           "kubernetes-server"
+        ]
+        platform: ["linux-arm64","linux-amd64"]
+        extension: ["tar.gz", "tar.gz.sha256sum"]
+    steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: k8s_output_${{ matrix.platform }}
+        path: _output/release-tars
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Display structure of downloaded files
+      run: ls -R
+      working-directory: _output
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.release.outputs.upload_url }}
+        asset_path: ./_output/release-tars/${{ matrix.assets }}-${{ matrix.platform }}.${{ matrix.extension}}
+        asset_name: ${{ matrix.assets }}-${{ matrix.platform }}.${{ matrix.extension }}
+        asset_content_type: application/tar+gzip

--- a/build/common.sh
+++ b/build/common.sh
@@ -418,6 +418,8 @@ function kube::build::run_build_command_ex() {
     --env "GOTOOLCHAIN=${GOTOOLCHAIN:-}"
     --env "GOFLAGS=${GOFLAGS:-}"
     --env "GOGCFLAGS=${GOGCFLAGS:-}"
+    --env "GOEXPERIMENT=boringcrypto"
+    --env "DBG=1"
     --env "SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH:-}"
     # mount source code / output dir
     --volume "${KUBE_ROOT}:${KUBE_CROSS_CONTAINER_ROOT}"

--- a/cmd/kube-apiserver/fips.go
+++ b/cmd/kube-apiserver/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/cmd/kube-controller-manager/fips.go
+++ b/cmd/kube-controller-manager/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/cmd/kube-scheduler/fips.go
+++ b/cmd/kube-scheduler/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/cmd/kubectl/fips.go
+++ b/cmd/kubectl/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/cmd/kubelet/fips.go
+++ b/cmd/kubelet/fips.go
@@ -1,0 +1,6 @@
+//go:build fips
+
+package main
+
+// enforce fips compliance if boringcrypto is enabled
+import _ "crypto/tls/fipsonly"

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1299,8 +1299,14 @@ func NodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSe
 	}
 
 	taints := node.Spec.Taints
-	fitsNodeName, fitsNodeAffinity, fitsTaints := predicates(logger, pod, node, taints)
-	if !fitsNodeName || !fitsNodeAffinity {
+	fitsNodeName := len(pod.Spec.NodeName) == 0 || pod.Spec.NodeName == node.Name
+	if !fitsNodeName {
+		return false, false
+	}
+
+	fitsNodeName, fitsNodeSelector, fitsNodeAffinity, fitsTaints := predicates(logger, pod, node, taints)
+
+	if !fitsNodeName || !fitsNodeSelector {
 		return false, false
 	}
 
@@ -1312,14 +1318,35 @@ func NodeShouldRunDaemonPod(logger klog.Logger, node *v1.Node, ds *apps.DaemonSe
 		return false, !hasUntoleratedTaint
 	}
 
+	if !fitsNodeAffinity {
+		// IgnoredDuringExecution means that if the node labels change after Kubernetes schedules the Pod, the Pod continues to run.
+		return false, true
+	}
+
 	return true, true
 }
 
 // predicates checks if a DaemonSet's pod can run on a node.
-func predicates(logger klog.Logger, pod *v1.Pod, node *v1.Node, taints []v1.Taint) (fitsNodeName, fitsNodeAffinity, fitsTaints bool) {
+func predicates(logger klog.Logger, pod *v1.Pod, node *v1.Node, taints []v1.Taint) (fitsNodeName, fitsNodeSelector, fitsNodeAffinity, fitsTaints bool) {
 	fitsNodeName = len(pod.Spec.NodeName) == 0 || pod.Spec.NodeName == node.Name
+
+	if len(pod.Spec.NodeSelector) > 0 {
+		selector := labels.SelectorFromSet(pod.Spec.NodeSelector)
+		fitsNodeSelector = selector.Matches(labels.Set(node.Labels))
+	} else {
+		fitsNodeSelector = true
+	}
+
+	if pod.Spec.Affinity != nil &&
+		pod.Spec.Affinity.NodeAffinity != nil &&
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+		affinity := nodeaffinity.NewLazyErrorNodeSelector(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution)
+		fitsNodeAffinity, _ = affinity.Match(node)
+	} else {
+		fitsNodeAffinity = true
+	}
+
 	// Ignore parsing errors for backwards compatibility.
-	fitsNodeAffinity, _ = nodeaffinity.GetRequiredNodeAffinity(pod).Match(node)
 	_, hasUntoleratedTaint := v1helper.FindMatchingUntoleratedTaint(logger, taints, pod.Spec.Tolerations, func(t *v1.Taint) bool {
 		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule
 	}, utilfeature.DefaultFeatureGate.Enabled(features.TaintTolerationComparisonOperators))
@@ -1460,10 +1487,12 @@ func (dsc *DaemonSetsController) syncNodeUpdate(ctx context.Context, nodeName st
 		//    - Need to create a new pod on this node
 		// 2. (!shouldContinueRunning && scheduled): Node no longer meets requirements but pod exists
 		//    - Need to delete the existing pod from this node
-		// 3. (scheduled && ds.Status.NumberMisscheduled > 0): DaemonSet pod exists and misscheduled count is nonzero.
-		//    - For example: a pod was scheduled before the node became unready and tainted; after the node becomes ready and taints are removed, the pod may now be valid again.
-		//    - Need to recalculate NumberMisscheduled to ensure the DaemonSet status accurately reflects the current scheduling state.
-		if (shouldRun && !scheduled) || (!shouldContinueRunning && scheduled) || (scheduled && ds.Status.NumberMisscheduled > 0) {
+		// 3. (!shouldRun && shouldContinueRunning): misschedule-able state for this DS on this node
+		//    (RequiredDuringSchedulingIgnoredDuringExecution affinity mismatch, or NoSchedule-tainted-but-NoExecute-tolerated).
+		//    Independent of `scheduled`: the by-node pod index can lag pod creation between
+		//    podControl.CreatePods and scheduler binding. The DS reconciler is idempotent.
+		// 4. (scheduled && ds.Status.NumberMisscheduled > 0): recovery — stale NumberMisscheduled needs recomputation.
+		if (shouldRun && !scheduled) || (!shouldContinueRunning && scheduled) || (!shouldRun && shouldContinueRunning) || (scheduled && ds.Status.NumberMisscheduled > 0) {
 			dsc.enqueueDaemonSet(ds)
 		}
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -923,6 +923,13 @@ func NewMainKubelet(ctx context.Context,
 				}
 				return cert, nil
 			}
+
+			// GetCertificate is only preferred over the certificate files by
+			// Golang TLS if the ClientHelloInfo.ServerName is set, which it is
+			// not when connecting to a host by IP address. Clear the files to
+			// force the use of GetCertificate.
+			kubeDeps.TLSOptions.CertFile = ""
+			kubeDeps.TLSOptions.KeyFile = ""
 		}
 	}
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -129,6 +129,7 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/userns"
 	"k8s.io/kubernetes/pkg/kubelet/util"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/kubelet/util/manager"
 	"k8s.io/kubernetes/pkg/kubelet/util/queue"
 	"k8s.io/kubernetes/pkg/kubelet/util/sliceutils"
@@ -3024,6 +3025,8 @@ func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 		// TODO: reconcile being calculated in the config manager is questionable, and avoiding
 		// extra syncs may no longer be necessary. Reevaluate whether Reconcile and Sync can be
 		// merged (after resolving the next two TODOs).
+		sidecarsStatus := status.GetSidecarsStatus(pod)
+		klog.Infof("Pod: %s, status: Present=%v,Ready=%v,ContainersWaiting=%v", format.Pod(pod), sidecarsStatus.SidecarsPresent, sidecarsStatus.SidecarsReady, sidecarsStatus.ContainersWaiting)
 
 		// Reconcile Pod "Ready" condition if necessary. Trigger sync pod for reconciliation.
 		// TODO: this should be unnecessary today - determine what is the cause for this to
@@ -3036,6 +3039,17 @@ func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 				UpdateType: kubetypes.SyncPodSync,
 				StartTime:  start,
 			})
+		} else if sidecarsStatus.ContainersWaiting {
+			// if containers aren't running and the sidecars are all ready trigger a sync so that the containers get started
+			if sidecarsStatus.SidecarsPresent && sidecarsStatus.SidecarsReady {
+				klog.Infof("Pod: %s: sidecars: sidecars are ready, dispatching work", format.Pod(pod))
+				kl.podWorkers.UpdatePod(UpdatePodOptions{
+					Pod:        pod,
+					MirrorPod:  mirrorPod,
+					UpdateType: kubetypes.SyncPodSync,
+					StartTime:  start,
+				})
+			}
 		}
 
 		// After an evicted pod is synced, all dead containers in the pod can be removed.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -810,6 +810,12 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.
 
 	l := getContainerInfoFromLabels(ctx, s.Labels)
 	a := getContainerInfoFromAnnotations(ctx, s.Annotations)
+
+	annotations := make(map[string]string)
+	if a.Sidecar {
+		annotations[fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", l.ContainerName)] = "Sidecar"
+	}
+
 	// Notice that the followings are not full spec. The container killing code should not use
 	// un-restored fields.
 	pod = &v1.Pod{
@@ -818,6 +824,7 @@ func (m *kubeGenericRuntimeManager) restoreSpecsFromContainerLabels(ctx context.
 			Name:                       l.PodName,
 			Namespace:                  l.PodNamespace,
 			DeletionGracePeriodSeconds: a.PodDeletionGracePeriod,
+			Annotations:                annotations,
 		},
 		Spec: v1.PodSpec{
 			TerminationGracePeriodSeconds: a.PodTerminationGracePeriod,
@@ -844,8 +851,15 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 	var containerSpec *v1.Container
 	if pod != nil {
 		if containerSpec = kubecontainer.GetContainerSpec(pod, containerName); containerSpec == nil {
-			return fmt.Errorf("failed to get containerSpec %q (id=%q) in pod %q when killing container for reason %q",
-				containerName, containerID.String(), format.Pod(pod), message)
+			// after a kubelet restart, it's not 100% certain that the
+			// pod we're given has the container we need in the spec
+			// -- we try to recover that here.
+			restoredPod, restoredContainer, err := m.restoreSpecsFromContainerLabels(ctx, containerID)
+			if err != nil {
+				return fmt.Errorf("failed to get containerSpec %q(id=%q) in pod %q when killing container for reason %q. error: %v",
+					containerName, containerID.String(), format.Pod(pod), message, err)
+			}
+			pod, containerSpec = restoredPod, restoredContainer
 		}
 	} else {
 		// Restore necessary information if one of the specs is nil.
@@ -909,9 +923,27 @@ func (m *kubeGenericRuntimeManager) killContainer(ctx context.Context, pod *v1.P
 // killContainersWithSyncResult kills all pod's containers with sync results.
 func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) (syncResults []*kubecontainer.SyncResult) {
 	logger := klog.FromContext(ctx)
-	containerResults := make(chan *kubecontainer.SyncResult, len(runningPod.Containers))
-	wg := sync.WaitGroup{}
+	// split out sidecars and non-sidecars
+	var (
+		sidecars    []*kubecontainer.Container
+		nonSidecars []*kubecontainer.Container
+	)
 
+	if gracePeriodOverride == nil {
+		minGracePeriod := int64(minimumGracePeriodInSeconds)
+		gracePeriodOverride = &minGracePeriod
+	}
+
+	for _, container := range runningPod.Containers {
+		if isSidecar(pod, container.Name) {
+			sidecars = append(sidecars, container)
+		} else {
+			nonSidecars = append(nonSidecars, container)
+		}
+	}
+	containerResults := make(chan *kubecontainer.SyncResult, len(runningPod.Containers))
+
+	wg := sync.WaitGroup{}
 	wg.Add(len(runningPod.Containers))
 	var termOrdering *terminationOrdering
 	if types.HasRestartableInitContainer(pod) {
@@ -921,6 +953,15 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(ctx context.Con
 		}
 		termOrdering = newTerminationOrdering(pod, runningContainerNames)
 	}
+
+	if len(sidecars) > 0 {
+		var runningContainerNames []string
+		for _, container := range runningPod.Containers {
+			runningContainerNames = append(runningContainerNames, container.Name)
+		}
+		termOrdering = lyftSidecarTerminationOrdering(pod, runningContainerNames)
+	}
+
 	for _, container := range runningPod.Containers {
 		go func(container *kubecontainer.Container) {
 			defer utilruntime.HandleCrash()

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -67,6 +67,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
+	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/kubernetes/pkg/kubelet/sysctl"
 	"k8s.io/kubernetes/pkg/kubelet/token"
 	"k8s.io/kubernetes/pkg/kubelet/types"
@@ -675,6 +676,14 @@ func podResourcesFromRequirements(requirements *v1.ResourceRequirements) podLeve
 	}
 }
 
+func isSidecar(pod *v1.Pod, containerName string) bool {
+	if pod == nil {
+		klog.V(5).Infof("isSidecar: pod is nil, so returning false")
+		return false
+	}
+	return pod.Annotations[fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", containerName)] == "Sidecar"
+}
+
 // computePodResizeAction determines the actions required (if any) to resize the given container.
 // Returns whether to keep (true) or restart (false) the container.
 // TODO(vibansal): Make this function to be agnostic to whether it is dealing with a restartable init container or not (i.e. remove the argument `isRestartableInitContainer`).
@@ -1155,6 +1164,17 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 		return changes
 	}
 
+	var sidecarNames []string
+	for _, container := range pod.Spec.Containers {
+		if isSidecar(pod, container.Name) {
+			sidecarNames = append(sidecarNames, container.Name)
+		}
+	}
+
+	// determine sidecar status
+	sidecarStatus := status.GetSidecarsStatus(pod)
+	klog.Infof("Pod: %s, sidecars: %s, status: Present=%v,Ready=%v,ContainersWaiting=%v", format.Pod(pod), sidecarNames, sidecarStatus.SidecarsPresent, sidecarStatus.SidecarsReady, sidecarStatus.ContainersWaiting)
+
 	// If we need to (re-)create the pod sandbox, everything will need to be
 	// killed and recreated, and init containers should be purged.
 	if createPodSandbox {
@@ -1214,6 +1234,14 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 
 			return changes
 		}
+		if len(sidecarNames) > 0 {
+			for idx, c := range pod.Spec.Containers {
+				if isSidecar(pod, c.Name) {
+					changes.ContainersToStart = append(changes.ContainersToStart, idx)
+				}
+			}
+			return changes
+		}
 		changes.ContainersToStart = containersToStart
 		return changes
 	}
@@ -1246,6 +1274,21 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	keepCount := 0
 	// check the status of containers.
 	for idx, container := range pod.Spec.Containers {
+		// this works because in other cases, if it was a sidecar, we
+		// are always allowed to handle the container.
+		//
+		// if it is a non-sidecar, and there are no sidecars, then
+		// we're are also always allowed to restart the container.
+		//
+		// if there are sidecars, then we can only restart non-sidecars under
+		// the following conditions:
+		// - the non-sidecars have run before (i.e. they are not in a Waiting state) OR
+		// - the sidecars are ready (we're starting them for the first time)
+		if !isSidecar(pod, container.Name) && sidecarStatus.SidecarsPresent && sidecarStatus.ContainersWaiting && !sidecarStatus.SidecarsReady {
+			klog.Infof("Pod: %s, Container: %s, sidecar=%v skipped: Present=%v,Ready=%v,ContainerWaiting=%v", format.Pod(pod), container.Name, isSidecar(pod, container.Name), sidecarStatus.SidecarsPresent, sidecarStatus.SidecarsReady, sidecarStatus.ContainersWaiting)
+			continue
+		}
+
 		containerStatus := podStatus.FindContainerStatusByName(container.Name)
 
 		// Call internal container post-stop lifecycle hook for any non-running container so that any
@@ -1330,6 +1373,7 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	}
 
 	if keepCount == 0 && len(changes.ContainersToStart) == 0 {
+		klog.Infof("Pod: %s: KillPod=true", format.Pod(pod))
 		changes.KillPod = true
 		// To prevent the restartable init containers to keep pod alive, we should
 		// not restart them.
@@ -1891,6 +1935,35 @@ func (m *kubeGenericRuntimeManager) doBackOff(ctx context.Context, pod *v1.Pod, 
 // only hard kill paths are allowed to specify a gracePeriodOverride in the kubelet in order to not corrupt user data.
 // it is useful when doing SIGKILL for hard eviction scenarios, or max grace period during soft eviction scenarios.
 func (m *kubeGenericRuntimeManager) KillPod(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+	// if the pod is nil, we need to recover it, so we can get the
+	// grace period and also the sidecar status.
+	if pod == nil {
+		for _, container := range runningPod.Containers {
+			klog.Infof("Pod: %s, KillPod: pod nil, trying to restore from container %s", runningPod.Name, container.ID)
+			podSpec, _, err := m.restoreSpecsFromContainerLabels(ctx, container.ID)
+			if err != nil {
+				klog.Errorf("Pod: %s, KillPod: couldn't restore: %s", runningPod.Name, container.ID)
+				continue
+			}
+			pod = podSpec
+			break
+		}
+	}
+
+	if gracePeriodOverride == nil && pod != nil {
+		switch {
+		case pod.DeletionGracePeriodSeconds != nil:
+			gracePeriodOverride = pod.DeletionGracePeriodSeconds
+		case pod.Spec.TerminationGracePeriodSeconds != nil:
+			gracePeriodOverride = pod.Spec.TerminationGracePeriodSeconds
+		}
+	}
+
+	if gracePeriodOverride == nil || *gracePeriodOverride < minimumGracePeriodInSeconds {
+		min := int64(minimumGracePeriodInSeconds)
+		gracePeriodOverride = &min
+	}
+
 	err := m.killPodWithSyncResult(ctx, pod, runningPod, gracePeriodOverride)
 	return err.Error()
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2417,6 +2417,13 @@ func makeBasePodAndStatusWithRestartableInitContainers() (*v1.Pod, *kubecontaine
 	return pod, status
 }
 
+func makeBasePodAndStatusWithSidecar() (*v1.Pod, *kubecontainer.PodStatus) {
+	pod, status := makeBasePodAndStatus()
+	pod.Annotations = map[string]string{fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", pod.Spec.Containers[1].Name): "Sidecar"}
+	status.ContainerStatuses[1].Hash = kubecontainer.HashContainer(&pod.Spec.Containers[1])
+	return pod, status
+}
+
 func TestComputePodActionsWithInitAndEphemeralContainers(t *testing.T) {
 	// Make sure existing test cases pass with feature enabled
 	TestComputePodActions(t)
@@ -2743,6 +2750,183 @@ func TestSyncPodWithSandboxAndDeletedPod(t *testing.T) {
 	result := m.SyncPod(tCtx, pod, podStatus, []v1.Secret{}, backOff, false)
 	// This will return an error if the pod has _not_ been deleted.
 	assert.NoError(t, result.Error())
+}
+
+func TestComputePodActionsWithSidecar(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	// Createing a pair reference pod and status for the test cases to refer
+	// the specific fields.
+	basePod, baseStatus := makeBasePodAndStatusWithSidecar()
+	for desc, test := range map[string]struct {
+		mutatePodFn    func(*v1.Pod)
+		mutateStatusFn func(*kubecontainer.PodStatus)
+		actions        podActions
+	}{
+		"Start sidecar containers before non-sidecars when creating a new pod": {
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				// No container or sandbox exists.
+				status.SandboxStatuses = []*runtimeapi.PodSandboxStatus{}
+				status.ContainerStatuses = []*kubecontainer.Status{}
+			},
+			actions: podActions{
+				KillPod:           true,
+				CreateSandbox:     true,
+				Attempt:           uint32(0),
+				ContainersToStart: []int{1},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+		"Don't start non-sidecars until sidecars are ready": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{
+						Name: "foo1",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+					{
+						Name:  "foo2",
+						Ready: false,
+					},
+					{
+						Name: "foo3",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				for i := range status.ContainerStatuses {
+					if i == 1 {
+						continue
+					}
+					status.ContainerStatuses[i].State = ""
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				ContainersToStart: []int{},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+		"Start non-sidecars when sidecars are ready": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{
+						Name: "foo1",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+					{
+						Name:  "foo2",
+						Ready: true,
+					},
+					{
+						Name: "foo3",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				for i := range status.ContainerStatuses {
+					if i == 1 {
+						continue
+					}
+					status.ContainerStatuses[i].State = ""
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				ContainersToStart: []int{0, 2},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+		"Restart only sidecars while non-sidecars are waiting": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.RestartPolicy = v1.RestartPolicyAlways
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{
+						Name: "foo1",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+					{
+						Name:  "foo2",
+						Ready: false,
+					},
+					{
+						Name: "foo3",
+						State: v1.ContainerState{
+							Waiting: &v1.ContainerStateWaiting{},
+						},
+					},
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				for i := range status.ContainerStatuses {
+					if i == 1 {
+						status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
+					}
+					status.ContainerStatuses[i].State = ""
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				ContainersToStart: []int{1},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+		"Restart running non-sidecars despite sidecar becoming not ready ": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.RestartPolicy = v1.RestartPolicyAlways
+				pod.Status.ContainerStatuses = []v1.ContainerStatus{
+					{
+						Name: "foo1",
+					},
+					{
+						Name:  "foo2",
+						Ready: false,
+					},
+					{
+						Name: "foo3",
+					},
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				for i := range status.ContainerStatuses {
+					if i == 1 {
+						continue
+					}
+					status.ContainerStatuses[i].State = kubecontainer.ContainerStateExited
+				}
+			},
+			actions: podActions{
+				SandboxID:         baseStatus.SandboxStatuses[0].Id,
+				ContainersToStart: []int{0, 2},
+				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
+			},
+		},
+	} {
+		pod, status := makeBasePodAndStatusWithSidecar()
+		if test.mutatePodFn != nil {
+			test.mutatePodFn(pod)
+		}
+		if test.mutateStatusFn != nil {
+			test.mutateStatusFn(status)
+		}
+		ctx := context.Background()
+		actions := m.computePodActions(ctx, pod, status, false)
+		verifyActions(t, &test.actions, &actions, desc)
+	}
 }
 
 func makeBasePodAndStatusWithInitAndEphemeralContainers() (*v1.Pod, *kubecontainer.PodStatus) {

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -194,9 +194,6 @@ func ListenAndServeKubeletServer(
 
 	if tlsOptions != nil {
 		s.TLSConfig = tlsOptions.Config
-		// Passing empty strings as the cert and key files means no
-		// cert/keys are specified and GetCertificate in the TLSConfig
-		// should be called instead.
 		if err := s.ListenAndServeTLS(tlsOptions.CertFile, tlsOptions.KeyFile); err != nil {
 			logger.Error(err, "Failed to listen and serve")
 			os.Exit(1)

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,13 +36,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	kubeutil "k8s.io/kubernetes/pkg/kubelet/util"
+	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	statusutil "k8s.io/kubernetes/pkg/util/pod"
 )
 
@@ -1370,4 +1371,74 @@ func (m *manager) recordInProgressResizeCount() {
 		}
 	}
 	metrics.PodInProgressResizes.Set(float64(inProgressResizeCount))
+}
+
+// SidecarsStatus contains three bools, whether the pod has sidecars,
+// if the all the sidecars are ready and if the non sidecars are in a
+// waiting state.
+type SidecarsStatus struct {
+	SidecarsPresent   bool
+	SidecarsReady     bool
+	ContainersWaiting bool
+}
+
+// GetSidecarsStatus returns the SidecarsStatus for the given pod
+// We assume the worst: if we are unable to determine the status of all containers we make defensive assumptions that
+// there are sidecars, they are not ready, and that there are non-sidecars waiting. This is to prevent starting non-
+// -sidecars accidentally.
+func GetSidecarsStatus(pod *v1.Pod) SidecarsStatus {
+	var containerStatusesCopy []v1.ContainerStatus
+	if pod == nil {
+		klog.Infof("Pod was nil, returning sidecar status that prevents progress")
+		return SidecarsStatus{SidecarsPresent: true, SidecarsReady: false, ContainersWaiting: true}
+	}
+	if pod.Spec.Containers == nil {
+		klog.Infof("Pod %s: Containers was nil, returning sidecar status that prevents progress", format.Pod(pod))
+		return SidecarsStatus{SidecarsPresent: true, SidecarsReady: false, ContainersWaiting: true}
+	}
+	if pod.Status.ContainerStatuses == nil {
+		klog.Infof("Pod %s: ContainerStatuses was nil, doing best effort using spec", format.Pod(pod))
+	} else {
+		// Make a copy of ContainerStatuses to avoid having the carpet pulled from under our feet
+		containerStatusesCopy = make([]v1.ContainerStatus, len(pod.Status.ContainerStatuses))
+		copy(containerStatusesCopy, pod.Status.ContainerStatuses)
+	}
+
+	sidecarsStatus := SidecarsStatus{SidecarsPresent: false, SidecarsReady: true, ContainersWaiting: false}
+	for _, container := range pod.Spec.Containers {
+		foundStatus := false
+		isSidecar := false
+		if pod.Annotations[fmt.Sprintf("sidecars.lyft.net/container-lifecycle-%s", container.Name)] == "Sidecar" {
+			isSidecar = true
+			sidecarsStatus.SidecarsPresent = true
+		}
+		for _, status := range containerStatusesCopy {
+			if status.Name == container.Name {
+				foundStatus = true
+				if isSidecar {
+					if !status.Ready {
+						klog.Infof("Pod %s: %s: sidecar not ready", format.Pod(pod), container.Name)
+						sidecarsStatus.SidecarsReady = false
+					} else {
+						klog.Infof("Pod %s: %s: sidecar is ready", format.Pod(pod), container.Name)
+					}
+				} else if status.State.Waiting != nil {
+					// check if non-sidecars have started
+					klog.Infof("Pod: %s: %s: non-sidecar waiting", format.Pod(pod), container.Name)
+					sidecarsStatus.ContainersWaiting = true
+				}
+				break
+			}
+		}
+		if !foundStatus {
+			if isSidecar {
+				klog.Infof("Pod %s: %s (sidecar): status not found, assuming not ready", format.Pod(pod), container.Name)
+				sidecarsStatus.SidecarsReady = false
+			} else {
+				klog.Infof("Pod: %s: %s (non-sidecar): status not found, assuming waiting", format.Pod(pod), container.Name)
+				sidecarsStatus.ContainersWaiting = true
+			}
+		}
+	}
+	return sidecarsStatus
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/activation.go
@@ -32,18 +32,18 @@ import (
 
 // newActivation creates an activation for CEL admission plugins from the given request, admission chain and
 // variable binding information.
-func newActivation(compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace) (*evaluationActivation, error) {
-	oldObjectVal, err := objectToResolveVal(versionedAttr.VersionedOldObject)
+func newActivation(ctx context.Context, compositionCtx CompositionContext, versionedAttr *admission.VersionedAttributes, request *admissionv1.AdmissionRequest, inputs OptionalVariableBindings, namespace *v1.Namespace) (*evaluationActivation, error) {
+	oldObjectVal, err := objectToResolveVal(ctx, versionedAttr.VersionedOldObject)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare oldObject variable for evaluation: %w", err)
 	}
-	objectVal, err := objectToResolveVal(versionedAttr.VersionedObject)
+	objectVal, err := objectToResolveVal(ctx, versionedAttr.VersionedObject)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare object variable for evaluation: %w", err)
 	}
 	var paramsVal, authorizerVal, requestResourceAuthorizerVal any
 	if inputs.VersionedParams != nil {
-		paramsVal, err = objectToResolveVal(inputs.VersionedParams)
+		paramsVal, err = objectToResolveVal(ctx, inputs.VersionedParams)
 		if err != nil {
 			return nil, fmt.Errorf("failed to prepare params variable for evaluation: %w", err)
 		}
@@ -54,11 +54,11 @@ func newActivation(compositionCtx CompositionContext, versionedAttr *admission.V
 		requestResourceAuthorizerVal = library.NewResourceAuthorizerVal(versionedAttr.GetUserInfo(), inputs.Authorizer, versionedAttr)
 	}
 
-	requestVal, err := convertObjectToUnstructured(request)
+	requestVal, err := convertObjectToUnstructured(ctx, request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare request variable for evaluation: %w", err)
 	}
-	namespaceVal, err := objectToResolveVal(namespace)
+	namespaceVal, err := objectToResolveVal(ctx, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare namespace variable for evaluation: %w", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
@@ -48,6 +48,19 @@ func ContextWithUnstructuredCache(ctx context.Context) context.Context {
 	return context.WithValue(ctx, unstructuredCacheKey{}, &sync.Map{})
 }
 
+// ContextWithUnstructuredCacheIfAbsent behaves like ContextWithUnstructuredCache, but is a
+// no-op if ctx already carries a cache. Bound policies sharing one object/oldObject/params
+// (e.g. all policies evaluated for one admission request in dispatcher.Dispatch) should wrap
+// ctx once at that outer scope so conversions are shared across policies, not just across the
+// 4 CEL passes within a single policy's Validate() call. Callers of Validate() that don't go
+// through that outer scope (e.g. tests, or direct callers) still get a cache of their own.
+func ContextWithUnstructuredCacheIfAbsent(ctx context.Context) context.Context {
+	if ctx.Value(unstructuredCacheKey{}) != nil {
+		return ctx
+	}
+	return ContextWithUnstructuredCache(ctx)
+}
+
 // conditionCompiler implement the interface ConditionCompiler.
 type conditionCompiler struct {
 	compiler Compiler

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/condition.go
@@ -19,6 +19,7 @@ package cel
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -29,6 +30,23 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/cel/environment"
 )
+
+// unstructuredCacheKey is the context key under which a per-Validate()-call
+// cache of object->unstructured conversions is stored. matchConditions,
+// validations, messageExpression and auditAnnotations are each evaluated as
+// separate ConditionEvaluator passes against the same object/oldObject/params,
+// and without this cache each pass independently repeats the same
+// reflection-based runtime.DefaultUnstructuredConverter.ToUnstructured() work.
+type unstructuredCacheKey struct{}
+
+// ContextWithUnstructuredCache returns a context that causes convertObjectToUnstructured
+// to memoize conversions by object pointer identity for the lifetime of the returned
+// context. Callers that invoke multiple ConditionEvaluator passes against the same
+// versionedAttr/params within one logical evaluation (e.g. validator.Validate) should
+// wrap their context with this once, upfront, so the passes share converted results.
+func ContextWithUnstructuredCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, unstructuredCacheKey{}, &sync.Map{})
+}
 
 // conditionCompiler implement the interface ConditionCompiler.
 type conditionCompiler struct {
@@ -62,9 +80,27 @@ func NewCondition(compilationResults []CompilationResult) ConditionEvaluator {
 	}
 }
 
-func convertObjectToUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
+func convertObjectToUnstructured(ctx context.Context, obj interface{}) (*unstructured.Unstructured, error) {
 	if obj == nil || reflect.ValueOf(obj).IsNil() {
 		return &unstructured.Unstructured{Object: nil}, nil
+	}
+	if cacheAny := ctx.Value(unstructuredCacheKey{}); cacheAny != nil {
+		cache := cacheAny.(*sync.Map)
+		// obj is always a pointer to a concrete runtime.Object/AdmissionRequest/Namespace,
+		// so it's comparable and safe to use as a map key directly.
+		if cached, ok := cache.Load(obj); ok {
+			return cached.(*unstructured.Unstructured), nil
+		}
+		ret, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+		if err != nil {
+			return nil, err
+		}
+		u := &unstructured.Unstructured{Object: ret}
+		// LoadOrStore rather than Store: if two passes race to convert the same
+		// object concurrently, keep whichever result was stored first so both
+		// return the identical value.
+		actual, _ := cache.LoadOrStore(obj, u)
+		return actual.(*unstructured.Unstructured), nil
 	}
 	ret, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {
@@ -73,11 +109,11 @@ func convertObjectToUnstructured(obj interface{}) (*unstructured.Unstructured, e
 	return &unstructured.Unstructured{Object: ret}, nil
 }
 
-func objectToResolveVal(r runtime.Object) (interface{}, error) {
+func objectToResolveVal(ctx context.Context, r runtime.Object) (interface{}, error) {
 	if r == nil || reflect.ValueOf(r).IsNil() {
 		return nil, nil
 	}
-	v, err := convertObjectToUnstructured(r)
+	v, err := convertObjectToUnstructured(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +131,7 @@ func (c *condition) ForInput(ctx context.Context, versionedAttr *admission.Versi
 	// if this activation supports composition, we will need the compositionCtx. It may be nil.
 	compositionCtx, _ := ctx.(CompositionContext)
 
-	activation, err := newActivation(compositionCtx, versionedAttr, request, inputs, namespace)
+	activation, err := newActivation(ctx, compositionCtx, versionedAttr, request, inputs, namespace)
 	if err != nil {
 		return nil, -1, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/mutation.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/cel/mutation.go
@@ -52,7 +52,7 @@ func (p *mutatingEvaluator) ForInput(ctx context.Context, versionedAttr *admissi
 	// if this activation supports composition, we will need the compositionCtx. It may be nil.
 	compositionCtx, _ := ctx.(CompositionContext)
 
-	activation, err := newActivation(compositionCtx, versionedAttr, request, inputs, namespace)
+	activation, err := newActivation(ctx, compositionCtx, versionedAttr, request, inputs, namespace)
 	if err != nil {
 		return EvaluationResult{}, -1, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
@@ -31,6 +31,7 @@ import (
 	utiljson "k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apiserver/pkg/admission"
 	admissionauthorizer "k8s.io/apiserver/pkg/admission/plugin/authorizer"
+	"k8s.io/apiserver/pkg/admission/plugin/cel"
 	"k8s.io/apiserver/pkg/admission/plugin/policy/generic"
 	celmetrics "k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics"
 	celconfig "k8s.io/apiserver/pkg/apis/cel"
@@ -70,6 +71,12 @@ func (c *dispatcher) Start(ctx context.Context) error {
 
 // Dispatch implements generic.Dispatcher.
 func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces, hooks []PolicyHook) error {
+	// All bound policies evaluated below validate against the same object/oldObject/params
+	// for this one admission request. Share one set of unstructured conversions across all
+	// of them (not just across the 4 CEL passes within a single policy's Validate() call),
+	// so the request pays for at most one conversion per distinct object instead of one per
+	// bound policy.
+	ctx = cel.ContextWithUnstructuredCache(ctx)
 
 	var deniedDecisions []policyDecisionWithMetadata
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
@@ -78,6 +78,18 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 	// bound policy.
 	ctx = cel.ContextWithUnstructuredCache(ctx)
 
+	// Bound policies that match the same GroupVersionKind of the incoming object all need an
+	// identical *admission.VersionedAttributes (it's a pure function of a, matchKind, and o,
+	// none of which vary across policies in this Dispatch call), but the per-hook loop below
+	// previously rebuilt one from scratch for every policy. That not only repeated the
+	// version-conversion work itself, it also defeated the unstructured-conversion cache above:
+	// each rebuilt VersionedAttributes has its own VersionedObject/VersionedOldObject pointers,
+	// so the cache (keyed by pointer identity) saw a fresh miss per policy despite the shared ctx.
+	// Building at most one VersionedAttributes per distinct matchKind lets policies sharing a
+	// GVK also share those pointers, so the unstructured cache actually reuses conversions
+	// across policies instead of just across one policy's 4 CEL passes.
+	versionedAttrsByKind := map[schema.GroupVersionKind]*admission.VersionedAttributes{}
+
 	var deniedDecisions []policyDecisionWithMetadata
 
 	addConfigError := func(err error, definition *admissionregistrationv1.ValidatingAdmissionPolicy, binding *admissionregistrationv1.ValidatingAdmissionPolicyBinding) {
@@ -127,7 +139,9 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 		// versionedAttributes will be set to non-nil inside of the loop, but
 		// is scoped outside of the param loop so we only convert once. We defer
 		// conversion so that it is only performed when we know a policy matches,
-		// saving the cost of converting non-matching requests.
+		// saving the cost of converting non-matching requests. It's seeded from
+		// versionedAttrsByKind so policies sharing matchKind with an earlier hook
+		// in this Dispatch call reuse that conversion instead of redoing it.
 		var versionedAttr *admission.VersionedAttributes
 
 		definition := hook.Policy
@@ -145,6 +159,8 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 			addConfigError(hook.ConfigurationError, definition, nil)
 			continue
 		}
+
+		versionedAttr = versionedAttrsByKind[matchKind]
 
 		auditAnnotationCollector := newAuditAnnotationCollector()
 		for _, binding := range hook.Bindings {
@@ -181,6 +197,7 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 					continue
 				}
 				versionedAttr = va
+				versionedAttrsByKind[matchKind] = va
 			}
 
 			var validationResults []ValidateResult

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/validator.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/validator.go
@@ -78,8 +78,11 @@ func (v *validator) Validate(ctx context.Context, matchedResource schema.GroupVe
 	// matchConditions, validations, messageExpression and auditAnnotations are each a
 	// separate CEL evaluation pass below, but all evaluate against the same
 	// object/oldObject/params. Share one set of unstructured conversions across all of
-	// them instead of each pass repeating the same reflection-based conversion.
-	ctx = cel.ContextWithUnstructuredCache(ctx)
+	// them instead of each pass repeating the same reflection-based conversion. Callers
+	// that evaluate multiple bound policies against the same object (e.g. dispatcher.Dispatch)
+	// should wrap ctx with this upfront so the cache is shared across policies too; this
+	// falls back to a fresh cache when that hasn't happened, so standalone callers still benefit.
+	ctx = cel.ContextWithUnstructuredCacheIfAbsent(ctx)
 
 	var f v1.FailurePolicyType
 	if v.failPolicy == nil {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/validator.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/validator.go
@@ -75,6 +75,12 @@ func auditAnnotationEvaluationForError(f v1.FailurePolicyType) PolicyAuditAnnota
 // runtimeCELCostBudget was added for testing purpose only. Callers should always use const RuntimeCELCostBudget from k8s.io/apiserver/pkg/apis/cel/config.go as input.
 
 func (v *validator) Validate(ctx context.Context, matchedResource schema.GroupVersionResource, versionedAttr *admission.VersionedAttributes, versionedParams runtime.Object, namespace *corev1.Namespace, runtimeCELCostBudget int64, authz authorizer.Authorizer) ValidateResult {
+	// matchConditions, validations, messageExpression and auditAnnotations are each a
+	// separate CEL evaluation pass below, but all evaluate against the same
+	// object/oldObject/params. Share one set of unstructured conversions across all of
+	// them instead of each pass repeating the same reflection-based conversion.
+	ctx = cel.ContextWithUnstructuredCache(ctx)
+
 	var f v1.FailurePolicyType
 	if v.failPolicy == nil {
 		f = v1.Fail

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -32,7 +32,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -40,7 +39,6 @@ import (
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
@@ -227,124 +225,128 @@ var _ = SIGDescribe("Pods Extended", func() {
 		})
 	})
 
-	ginkgo.Describe("Pod Container lifecycle", func() {
-		var podClient *e2epod.PodClient
-		ginkgo.BeforeEach(func() {
-			podClient = e2epod.NewPodClient(f)
-		})
-
-		ginkgo.It("should not create extra sandbox if all containers are done", func(ctx context.Context) {
-			ginkgo.By("creating the pod that should always exit 0")
-
-			name := "pod-always-succeed" + string(uuid.NewUUID())
-			image := imageutils.GetE2EImage(imageutils.BusyBox)
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					InitContainers: []v1.Container{
-						{
-							Name:  "foo",
-							Image: image,
-							Command: []string{
-								"/bin/true",
-							},
-						},
-					},
-					Containers: []v1.Container{
-						{
-							Name:  "bar",
-							Image: image,
-							Command: []string{
-								"/bin/true",
-							},
-						},
-					},
-				},
-			}
-
-			ginkgo.By("submitting the pod to kubernetes")
-			createdPod := podClient.Create(ctx, pod)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
+	/*
+		// For now the a2a9964a66ef481d10db3ffc15d4b26a234d0bdd fix isn't compatible with
+		// the sidecar patchset we keep in this fork. Comment out related tests.
+		ginkgo.Describe("Pod Container lifecycle", func() {
+			var podClient *e2epod.PodClient
+			ginkgo.BeforeEach(func() {
+				podClient = e2epod.NewPodClient(f)
 			})
 
-			framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+			ginkgo.It("should not create extra sandbox if all containers are done", func() {
+				ginkgo.By("creating the pod that should always exit 0")
 
-			var eventList *v1.EventList
-			var err error
-			ginkgo.By("Getting events about the pod")
-			framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
-				selector := fields.Set{
-					"involvedObject.kind":      "Pod",
-					"involvedObject.uid":       string(createdPod.UID),
-					"involvedObject.namespace": f.Namespace.Name,
-					"source":                   "kubelet",
-				}.AsSelector().String()
-				options := metav1.ListOptions{FieldSelector: selector}
-				eventList, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, options)
-				if err != nil {
-					return false, err
-				}
-				if len(eventList.Items) > 0 {
-					return true, nil
-				}
-				return false, nil
-			}))
-
-			ginkgo.By("Checking events about the pod")
-			for _, event := range eventList.Items {
-				if event.Reason == events.SandboxChanged {
-					framework.Fail("Unexpected SandboxChanged event")
-				}
-			}
-		})
-
-		ginkgo.It("evicted pods should be terminal", func(ctx context.Context) {
-			ginkgo.By("creating the pod that should be evicted")
-
-			name := "pod-should-be-evicted" + string(uuid.NewUUID())
-			image := imageutils.GetE2EImage(imageutils.BusyBox)
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					Containers: []v1.Container{
-						{
-							Name:  "bar",
-							Image: image,
-							Command: []string{
-								"/bin/sh", "-c", "sleep 10; dd if=/dev/zero of=file bs=1M count=10; sleep 10000",
-							},
-							Resources: v1.ResourceRequirements{
-								Limits: v1.ResourceList{
-									"ephemeral-storage": resource.MustParse("5Mi"),
+				name := "pod-always-succeed" + string(uuid.NewUUID())
+				image := imageutils.GetE2EImage(imageutils.BusyBox)
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+					Spec: v1.PodSpec{
+						RestartPolicy: v1.RestartPolicyOnFailure,
+						InitContainers: []v1.Container{
+							{
+								Name:  "foo",
+								Image: image,
+								Command: []string{
+									"/bin/true",
 								},
-							}},
+							},
+						},
+						Containers: []v1.Container{
+							{
+								Name:  "bar",
+								Image: image,
+								Command: []string{
+									"/bin/true",
+								},
+							},
+						},
 					},
-				},
-			}
+				}
 
-			ginkgo.By("submitting the pod to kubernetes")
-			podClient.Create(ctx, pod)
-			ginkgo.DeferCleanup(func(ctx context.Context) error {
-				ginkgo.By("deleting the pod")
-				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
+				ginkgo.By("submitting the pod to kubernetes")
+				createdPod := podClient.Create(pod)
+				defer func() {
+					ginkgo.By("deleting the pod")
+					podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				}()
+
+				framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(f.ClientSet, pod.Name, f.Namespace.Name))
+
+				var eventList *v1.EventList
+				var err error
+				ginkgo.By("Getting events about the pod")
+				framework.ExpectNoError(wait.Poll(time.Second*2, time.Second*60, func() (bool, error) {
+					selector := fields.Set{
+						"involvedObject.kind":      "Pod",
+						"involvedObject.uid":       string(createdPod.UID),
+						"involvedObject.namespace": f.Namespace.Name,
+						"source":                   "kubelet",
+					}.AsSelector().String()
+					options := metav1.ListOptions{FieldSelector: selector}
+					eventList, err = f.ClientSet.CoreV1().Events(f.Namespace.Name).List(context.TODO(), options)
+					if err != nil {
+						return false, err
+					}
+					if len(eventList.Items) > 0 {
+						return true, nil
+					}
+					return false, nil
+				}))
+
+				ginkgo.By("Checking events about the pod")
+				for _, event := range eventList.Items {
+					if event.Reason == events.SandboxChanged {
+						framework.Fail("Unexpected SandboxChanged event")
+					}
+				}
 			})
 
-			// Intentionally increase the timeout to ensure the metrics availability required for this test.
-			err := e2epod.WaitForPodTerminatedInNamespaceTimeout(ctx, f.ClientSet, pod.Name, "Evicted", f.Namespace.Name, 10*time.Minute)
-			if err != nil {
-				framework.Failf("error waiting for pod to be evicted: %v", err)
-			}
+			ginkgo.It("evicted pods should be terminal", func() {
+				ginkgo.By("creating the pod that should be evicted")
 
+				name := "pod-should-be-evicted" + string(uuid.NewUUID())
+				image := imageutils.GetE2EImage(imageutils.BusyBox)
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: name,
+					},
+					Spec: v1.PodSpec{
+						RestartPolicy: v1.RestartPolicyOnFailure,
+						Containers: []v1.Container{
+							{
+								Name:  "bar",
+								Image: image,
+								Command: []string{
+									"/bin/sh", "-c", "sleep 10; dd if=/dev/zero of=file bs=1M count=10; sleep 10000",
+								},
+								Resources: v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"ephemeral-storage": resource.MustParse("5Mi"),
+									},
+								}},
+						},
+					},
+				}
+
+				ginkgo.By("submitting the pod to kubernetes")
+				podClient.Create(pod)
+				defer func() {
+					ginkgo.By("deleting the pod")
+					podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+				}()
+
+				// Intentionally increase the timeout to ensure the metrics availability required for this test.
+				err := e2epod.WaitForPodTerminatedInNamespaceTimeout(ctx, f.ClientSet, pod.Name, "Evicted", f.Namespace.Name, 10*time.Minute)
+				if err != nil {
+					framework.Failf("error waiting for pod to be evicted: %v", err)
+				}
+
+			})
 		})
-	})
+	*/
 
 	ginkgo.Describe("Pod TerminationGracePeriodSeconds is negative", func() {
 		var podClient *e2epod.PodClient

--- a/test/e2e_node/kubelet_tls_test.go
+++ b/test/e2e_node/kubelet_tls_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/kubernetes/pkg/cluster/ports"
+	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+func createCertAndKeyFiles(certDir string) (string, string, error) {
+	cert, key, err := cert.GenerateSelfSignedCertKey(
+		"localhost",
+		[]net.IP{{127, 0, 0, 1}},
+		[]string{"localhost"},
+	)
+	if err != nil {
+		return "", "", nil
+	}
+
+	certPath := filepath.Join(certDir, "kubelet.cert")
+	keyPath := filepath.Join(certDir, "kubelet.key")
+	if err = os.WriteFile(certPath, cert, os.FileMode(0644)); err != nil {
+		return "", "", err
+	}
+
+	if err = os.WriteFile(keyPath, key, os.FileMode(0600)); err != nil {
+		return "", "", err
+	}
+
+	return certPath, keyPath, nil
+}
+
+func getCert(addr string) (*x509.Certificate, error) {
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = conn.Close() }()
+
+	return conn.ConnectionState().PeerCertificates[0], nil
+}
+
+var _ = SIGDescribe("KubletTLS", framework.WithSerial(), framework.WithNodeConformance(), func() {
+	f := framework.NewDefaultFramework("kubelet-tls-test")
+
+	ginkgo.Context("certificate reload", func() {
+		var tempDir string
+
+		t := ginkgo.GinkgoT()
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			tempDir = t.TempDir()
+			cfg, err := getCurrentKubeletConfig(ctx)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func(ctx context.Context, cfg *kubeletconfig.KubeletConfiguration) {
+				updateKubeletConfig(ctx, f, cfg, true)
+			}, cfg.DeepCopy())
+
+			certPath, keyPath, err := createCertAndKeyFiles(tempDir)
+			framework.ExpectNoError(err)
+
+			cfg.TLSCertFile = certPath
+			cfg.TLSPrivateKeyFile = keyPath
+			updateKubeletConfig(ctx, f, cfg, true)
+		})
+
+		ginkgo.It("should reload certificates from disk", func(ctx context.Context) {
+			addr := fmt.Sprintf("127.0.0.1:%d", ports.KubeletPort)
+			oldCert, err := getCert(addr)
+			framework.ExpectNoError(err)
+
+			_, _, err = createCertAndKeyFiles(tempDir)
+			framework.ExpectNoError(err)
+
+			gomega.Eventually(ctx, func(ctx context.Context) (bool, error) {
+				newCert, err := getCert(addr)
+				if err != nil {
+					return true, err
+				}
+
+				return newCert.Equal(oldCert), nil
+			}).Should(gomega.BeFalseBecause("new certificate should be loaded"))
+		})
+	})
+})

--- a/vendor/github.com/coreos/go-oidc/jwks.go
+++ b/vendor/github.com/coreos/go-oidc/jwks.go
@@ -109,7 +109,7 @@ func (r *remoteKeySet) verify(ctx context.Context, jws *jose.JSONWebSignature) (
 		break
 	}
 
-	keys, expiry := r.keysFromCache()
+	keys, _ := r.keysFromCache()
 
 	// Don't check expiry yet. This optimizes for when the provider is unavailable.
 	for _, key := range keys {
@@ -120,11 +120,11 @@ func (r *remoteKeySet) verify(ctx context.Context, jws *jose.JSONWebSignature) (
 		}
 	}
 
-	if !r.now().Add(keysExpiryDelta).After(expiry) {
-		// Keys haven't expired, don't refresh.
-		return nil, errors.New("failed to verify id token signature")
-	}
-
+	// If the kid doesn't match any cached key, always fetch from remote regardless
+	// of cache TTL. The OIDC provider may have added new signing keys since the
+	// last fetch (e.g. EKS returns max-age=604800 but rotates keys within that window).
+	//
+	// https://openid.net/specs/openid-connect-core-1_0.html#RotateSigKeys
 	keys, err := r.keysFromRemote(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fetching keys %v", err)


### PR DESCRIPTION
## Why

ValidatingAdmissionPolicy (VAP) evaluation was costing ~1.4-2ms per bound policy in production (confirmed via Datadog APM trace analysis on squirtle-b), dominated by `runtime.DefaultUnstructuredConverter.ToUnstructured()` — a reflection-driven, ~400-500µs-per-call conversion of `object`/`oldObject` from typed Go structs to `map[string]interface{}` for CEL evaluation.

That conversion was being repeated far more often than necessary, at two different levels:

1. **Within one policy.** Each bound policy's `Validate()` call runs 4 separate CEL evaluation passes over the same object/oldObject — `matchConditions`, `validations`, `messageExpression`, `auditAnnotations` — but each pass independently re-converted the same object.
2. **Across policies.** A single admission request commonly has many bound VAP policies evaluated against the *same* object (15 in the production trace that motivated this). `admission.VersionedAttributes` (which wraps the object being converted) was rebuilt fresh, with fresh pointers, once per bound policy — so even a per-policy conversion cache saw a fresh miss on every policy, since the cache is keyed by object pointer identity.

## What changed

Three incremental fixes, applied together:

1. **`cel/condition.go`, `cel/activation.go`, `cel/mutation.go`, `policy/validating/validator.go`** — add a `context`-scoped cache (`ContextWithUnstructuredCache`) keyed by object pointer identity, and wrap `validator.Validate()`'s context with it. This means the 4 CEL passes within one `Validate()` call share a single conversion instead of each redoing it.
2. **`policy/validating/dispatcher.go`** — hoist that same cache up to `Dispatch()`, before the per-policy loop, so it's shared across *all* bound policies evaluated for one admission request, not just within one policy's 4 passes. `Validate()` falls back to creating its own cache when called without that outer scope (e.g. from tests or other callers), so this is backward compatible.
3. **`policy/validating/dispatcher.go`** — the cache hoist alone wasn't sufficient: `admission.VersionedAttributes` is a pure function of `(a, matchKind, o)`, none of which vary across policies sharing a `GroupVersionKind` within one `Dispatch()` call, but it was being rebuilt from scratch per policy — defeating the cache above, since each rebuild produces new `VersionedObject`/`VersionedOldObject` pointers. Build at most one `VersionedAttributes` per distinct `matchKind` (`versionedAttrsByKind`) and reuse it across policies that share that GVK, so the cache actually produces cross-policy hits.

## Verification

- Isolated Go benchmark (4 CEL passes, 1 policy): 333µs → 51µs per cycle (6.5x), 4869 → 701 allocs.
- Isolated Go benchmark modeling 15 same-GVK bound policies, comparing per-policy `VersionedAttributes` rebuild (pre-fix behavior) vs. reuse-by-`matchKind` (post-fix behavior): 461.7µs → 203.3µs (2.3x), 4640 → 2646 allocs.
- Local kind-cluster deployment with temporary debug logging (not included in this PR) confirmed the fix engages as designed in the real dispatcher: for a request with 14 bound policies sharing one GVK, exactly 1 `VersionedAttributes` build + 13 reuses, and the shared object's conversion cache showing 1 miss followed by many hits instead of one miss per policy.
- The base fix (commit 1, item 1 above) has already been deployed to squirtle-b and confirmed via production trace analysis to reduce per-policy VAP evaluation cost from ~1.4-2ms to ~0.55ms median.

`go test ./pkg/admission/plugin/cel/... ./pkg/admission/plugin/policy/validating/...` passes.

## Not included

- Tracing/span instrumentation around `hook.Evaluator.Validate()` calls (unrelated observability work, out of scope for this PR).
- Debug logging used to verify cache hit/miss and VersionedAttributes reuse behavior in the local kind cluster (local-only, not intended to ship).